### PR TITLE
feat: native Ollama runtime with context window and reasoning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ Ollama Agent is a powerful command-line tool (CLI and REPL) that allows you to i
 
 - **Interactive REPL**: A modern, terminal-based chat interface with Markdown rendering and slash commands.
 - **Non-Interactive CLI**: Execute single prompts directly from your command line for quick queries.
-- **Ollama Integration**: Connects to any Ollama-compatible API endpoint.
+- **Native Ollama Integration**: Connects directly to Ollama's native API (via `langchain-ollama`), no OpenAI compatibility layer needed.
+- **Thinking / Reasoning**: Leverages Ollama's native [thinking capability](https://docs.ollama.com/capabilities/thinking) to expose model reasoning traces. Configurable per model via `--effort`.
+- **Automatic Context Window**: Resolves the model's effective context window (`num_ctx`) automatically from Ollama metadata, or allows manual override in config.
 - **Per-session Model Switching**: Change the model mid-conversation and continue from that point with the new model (context preserved). The change is not permanent and only affects the current session.
 - **Screen Vision (Screenshots)**: Attach monitor screenshots in prompts using `@dpN` for visual context.
 - **Tool-Powered**: The agent can execute shell commands via an integrated shell backend, allowing it to interact with your local environment to perform tasks.
 - **Delegated MCP Agents**: Each configured MCP server can run through its own lightweight DeepAgents sub-agent (via `langchain-mcp-adapters`) with custom model and instructions.
 - **Session Management**: Conversations are automatically saved and can be reloaded, deleted, or switched between.
 - **Task Management**: Save frequently used prompts as "tasks" and execute them with a simple command.
-- **Configurable**: Easily configure the model, API endpoint, and agent reasoning effort.
+- **Configurable**: Easily configure the model, Ollama host, context window, and reasoning effort.
 - **Mem0 Memory Layer**: Persistent memory backed by Mem0 + Qdrant, exposed through function-calling tools.
 - **RAG (Retrieval Augmented Generation)**: Create and manage document databases for context-aware responses using local embeddings and Qdrant.
 - **Skills**: Extend the agent with reusable, on-demand capabilities via the [Agent Skills specification](https://agentskills.io/specification). Skills provide task-specific instructions and context through progressive disclosure.
@@ -124,7 +126,17 @@ ollama-agent --model "gpt-oss:20b" --effort "high" --prompt "What is the current
 ollama-agent -m "gpt-oss:20b" -e "high" -p "What is the current date?"
 ```
 
-**Note**: reasoning effort (`--effort`) currently **only has an effect with `gpt-oss` models**. For other models, set `--effort disabled` (or `reasoning_effort=disabled` in config/tasks) to avoid unexpected behavior.
+**Thinking / Reasoning effort** — the `--effort` flag maps to Ollama's native [`think` parameter](https://docs.ollama.com/capabilities/thinking). Thinking-capable models emit a `thinking` field that separates their reasoning trace from the final answer.
+
+| Model family | `--effort` value | Ollama `think` value | Behaviour |
+|---|---|---|---|
+| **GPT-OSS** | `low` / `medium` / `high` | `"low"` / `"medium"` / `"high"` | Sets the thinking trace length. GPT-OSS only accepts these levels; `true`/`false` is ignored. |
+| **GPT-OSS** | `disabled` | *(not sent)* | GPT-OSS cannot fully disable thinking — a warning is emitted and the model uses its default behaviour. |
+| **Other thinking models** (Qwen 3, DeepSeek R1, DeepSeek-v3.1, …) | any except `disabled` | `true` | Enables thinking. |
+| **Other thinking models** | `disabled` | `false` | Disables thinking. |
+| **Non-thinking models** | *(any)* | *(not sent)* | Setting is ignored. |
+
+Thinking is enabled by default in Ollama for supported models. See the [Ollama thinking docs](https://docs.ollama.com/capabilities/thinking) for the full list of supported models and API details.
 
 ```bash
 ollama-agent --builtin-tool-timeout 60 --prompt "Run a long-running task"
@@ -209,7 +221,34 @@ ollama-agent task-delete <task_id>
 
 ## Configuration
 
-On the first run, the application will create a default configuration file at `~/.ollama-agent/config.ini`. You can edit this file to permanently change the default model, API URL, and other settings.
+On the first run, the application will create a default configuration file at `~/.ollama-agent/config.ini`. You can edit this file to permanently change the default model, Ollama host, and other settings.
+
+Example default section:
+
+```ini
+[default]
+model = qwen3.5:9b
+base_url = http://localhost:11434
+reasoning_effort = medium
+context_window =
+```
+
+| Key | Description |
+|---|---|
+| `model` | Default Ollama model. Must support tool calling. |
+| `base_url` | Native Ollama host (e.g. `http://localhost:11434`). Must **not** contain an `/v1` path — if detected, the app will exit with an error asking you to update the value. |
+| `reasoning_effort` | Default thinking level: `low`, `medium`, `high`, or `disabled`. See [Thinking / Reasoning](#common-options) above. |
+| `context_window` | If set, forces the runtime `num_ctx` for the selected model. Leave empty to let the app resolve it automatically (see below). |
+
+### Context Window Resolution
+
+Ollama Agent needs to know the effective context window (`num_ctx`) for every model. The runtime resolves it in this order:
+
+1. `context_window` from `config.ini`, if defined.
+2. `PARAMETER num_ctx` from `ollama show <model>` (the model's Modelfile).
+3. The model's reported `*.context_length` metadata from `ollama show <model>`.
+
+If none of those sources provides a value, the app exits with a clear error asking you to set `context_window` in `config.ini`.
 
 ### Configuration Reset
 
@@ -362,7 +401,7 @@ When a prompt arrives, the agent checks skill descriptions to find relevant ones
 
 Each skill is a directory containing at least a `SKILL.md` file with YAML frontmatter:
 
-```
+```text
 ~/.ollama-agent/skills/
 ├── langgraph-docs/
 │   └── SKILL.md

--- a/ollama_agent/__init__.py
+++ b/ollama_agent/__init__.py
@@ -1,6 +1,6 @@
 """Ollama Agent - AI agent to interact with local models."""
 
-__version__ = "0.2.6"
+__version__ = "0.3.0"
 
 from .agent import OllamaAgent, create_agent
 from .core import (

--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -10,11 +10,15 @@ from typing import Any, AsyncGenerator, cast
 
 from deepagents import create_deep_agent
 from deepagents.backends import LocalShellBackend
-from langchain_openai import ChatOpenAI
 
-from ..core import ReasoningEffortValue, assistant_text_from_messages, final_text_from_state
-from ..core import validate_reasoning_effort
-from ..core import ensure_model_supports_tools
+from ..core import (
+    ReasoningEffortValue,
+    assistant_text_from_messages,
+    create_ollama_chat_model,
+    ensure_model_supports_tools,
+    final_text_from_state,
+    validate_reasoning_effort,
+)
 from ..memory import Mem0Settings, MemoryManager
 from ..rag import RAGManager, RAGSettings
 from ..settings import RunningMCPServer, cleanup_mcp_servers, initialize_mcp_servers, load_instructions
@@ -48,9 +52,10 @@ class OllamaAgent:
     """AI agent backed by Ollama with tool support."""
 
     model: str
-    base_url: str = "http://localhost:11434/v1/"  # OpenAI-compatible Ollama endpoint
+    base_url: str = "http://localhost:11434"  # Kept configurable for local or remote Ollama hosts.
     api_key: str = "ollama"  # kept for config compatibility
     reasoning_effort: ReasoningEffortValue = "medium"
+    context_window: int | None = None
     database_path: Path | None = None
     mcp_config_path: Path | None = None
     mem0_settings: Mem0Settings = field(default_factory=Mem0Settings)
@@ -90,6 +95,8 @@ class OllamaAgent:
                 default_model=self.model,
                 base_url=self.base_url,
                 api_key=self.api_key,
+                context_window=self.context_window,
+                reasoning_effort=self.reasoning_effort,
             )
         self._initialized = True
 
@@ -113,27 +120,21 @@ class OllamaAgent:
             validate_reasoning_effort(effort) if effort else self.reasoning_effort,
         )
 
-    def _build_deep_agent(self, model: str, effort: ReasoningEffortValue):
-        ensure_model_supports_tools(model)
+    def _build_deep_agent(self, model: str, effort: ReasoningEffortValue) -> tuple[Any, list[str]]:
+        ensure_model_supports_tools(model, self.base_url)
 
-        # `reasoning_effort` must work for gpt-oss models as in the main branch,
-        # but the system prompt must remain exclusively user-defined.
-        openai_kwargs: dict[str, Any] = {
-            "model_name": model,
-            "openai_api_base": self.base_url,
-            "openai_api_key": self.api_key,
-            "temperature": 0,
-            # Always use the Responses API so reasoning/thinking tokens are
-            # streamed as structured content blocks (type='reasoning').
-            # The chat completions API drops Ollama's ``reasoning`` field.
-            "use_responses_api": True,
-            "streaming": True,
-        }
-        if "gpt-oss" in model.lower() and effort != "disabled":
-            openai_kwargs["reasoning_effort"] = effort
+        warnings: list[str] = []
 
         kwargs: dict[str, Any] = {
-            "model": ChatOpenAI(**openai_kwargs),
+            "model": create_ollama_chat_model(
+                model=model,
+                base_url=self.base_url,
+                api_key=self.api_key,
+                context_window=self.context_window,
+                reasoning_effort=effort,
+                temperature=0,
+                warn_callback=warnings.append,
+            ),
             "tools": list(BUILTIN_TOOLS),
             "system_prompt": self._instructions,
             "subagents": [srv.subagent for srv in self._mcp_servers],
@@ -144,16 +145,18 @@ class OllamaAgent:
         }
         if self.skills_dirs:
             kwargs["skills"] = list(self.skills_dirs)
-        return create_deep_agent(**kwargs)
+        return create_deep_agent(**kwargs), warnings
 
     async def run_async(self, prompt: object, model: str | None = None, reasoning_effort: str | None = None) -> str:
         await self.initialize()
         m, e = self._resolve(model, reasoning_effort)
-        agent = self._build_deep_agent(m, e)
+        agent, warnings = self._build_deep_agent(m, e)
         history = self._session_manager.get_message_dicts()
         user_text_for_history = prompt if isinstance(prompt, str) else str(prompt)
         self._session_manager.append_message("user", user_text_for_history)
         try:
+            for warning in warnings:
+                logger.warning(warning)
             state = await agent.ainvoke({"messages": [*history, _maybe_attach_screen_context(prompt)]})
             out = final_text_from_state(state)
             self._session_manager.append_message("assistant", out)
@@ -167,7 +170,7 @@ class OllamaAgent:
     ) -> AsyncGenerator[dict[str, Any], None]:
         await self.initialize()
         m, e = self._resolve(model, reasoning_effort)
-        agent = self._build_deep_agent(m, e)
+        agent, warnings = self._build_deep_agent(m, e)
 
         history = self._session_manager.get_message_dicts()
         history_len = len(history)
@@ -178,6 +181,9 @@ class OllamaAgent:
         emitted_text = ""
         emitted_from_messages = False
         try:
+            for warning in warnings:
+                yield {"type": "warning", "content": warning}
+
             async for mode, event in agent.astream(
                 {"messages": [*history, _maybe_attach_screen_context(prompt)]},
 
@@ -214,9 +220,10 @@ class OllamaAgent:
                         continue
 
                     content = getattr(chunk, "content", None)
+                    additional_kwargs = getattr(chunk, "additional_kwargs", None)
 
                     # Check for reasoning/thinking tokens first (chain-of-thought).
-                    reasoning = streaming_reasoning(content)
+                    reasoning = streaming_reasoning(content, additional_kwargs)
                     if reasoning:
                         yield {"type": "reasoning_delta", "content": reasoning}
                         continue

--- a/ollama_agent/agent/factory.py
+++ b/ollama_agent/agent/factory.py
@@ -34,6 +34,7 @@ def create_agent(
             base_url=cfg.base_url,
             api_key=cfg.api_key,
             reasoning_effort=effort,
+            context_window=cfg.context_window,
             database_path=cfg.database_path,
             mcp_config_path=cfg.mcp_config_path,
             mem0_settings=mem0,

--- a/ollama_agent/core/__init__.py
+++ b/ollama_agent/core/__init__.py
@@ -15,8 +15,13 @@ from .common import (
 )
 from .models import (
     ModelCapabilityError,
+    ModelContextWindowError,
+    create_ollama_chat_model,
     ensure_model_supports_tools,
     model_supports_tools,
+    model_supports_thinking,
+    resolve_context_window,
+    resolve_ollama_reasoning,
     validate_reasoning_effort,
 )
 from .resource_manager import BaseFileStoreManager
@@ -32,8 +37,13 @@ __all__ = [
     "ReasoningEffortValue",
     # Models
     "ModelCapabilityError",
+    "ModelContextWindowError",
+    "create_ollama_chat_model",
     "ensure_model_supports_tools",
     "model_supports_tools",
+    "model_supports_thinking",
+    "resolve_context_window",
+    "resolve_ollama_reasoning",
     "validate_reasoning_effort",
     # Utils
     "assistant_text_from_messages",

--- a/ollama_agent/core/models.py
+++ b/ollama_agent/core/models.py
@@ -1,30 +1,86 @@
-"""Model capabilities and validation logic."""
+"""Model capabilities, runtime creation, and validation logic."""
+
+from __future__ import annotations
 
 import logging
+import re
 from functools import lru_cache
-from typing import Iterable, cast
+from typing import Any, Callable, Iterable, cast
 
 import ollama
+from langchain_ollama import ChatOllama
 
 from .common import ALLOWED_REASONING_EFFORTS, DEFAULT_REASONING_EFFORT, ReasoningEffortValue
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "http://localhost:11434"
+
+THINKING_MODEL_PREFIXES = (
+    "deepseek-r1",
+    "deepseek-v3.1",
+    "gpt-oss",
+    "qwen3",
+)
 
 
 class ModelCapabilityError(RuntimeError):
     """Raised when the selected model cannot run tool calls."""
 
 
+class ModelContextWindowError(RuntimeError):
+    """Raised when the context window for a model cannot be resolved."""
+
+
+def _show_model(model: str, base_url: str | None = None) -> Any:
+    """Fetch and cache Ollama model metadata."""
+    return _show_model_cached(model, (base_url or DEFAULT_BASE_URL).rstrip("/"))
+
+
 @lru_cache(maxsize=None)
-def _get_capabilities(model: str) -> set[str]:
-    """Fetch and cache capabilities for a model."""
+def _show_model_cached(model: str, host: str) -> Any:
     try:
-        response = ollama.show(model)
+        return ollama.Client(host=host).show(model)
     except Exception as exc:
         raise ModelCapabilityError(
-            f"Failed to fetch metadata for '{model}': {exc}") from exc
+            f"Failed to fetch metadata for '{model}': {exc}"
+        ) from exc
 
-    payload = getattr(response, "capabilities", {})
+
+def _response_field(payload: Any, field: str, default: Any = None) -> Any:
+    if isinstance(payload, dict):
+        return payload.get(field, default)
+    return getattr(payload, field, default)
+
+
+def _parse_num_ctx(text: Any) -> int | None:
+    if not isinstance(text, str):
+        return None
+    match = re.search(r"^\s*(?:PARAMETER\s+)?num_ctx\s+(\d+)\s*$", text, re.IGNORECASE | re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+def _model_context_length(model_info: Any) -> int | None:
+    if not isinstance(model_info, dict):
+        return None
+
+    values: list[int] = []
+    for key, value in model_info.items():
+        if not str(key).endswith(".context_length"):
+            continue
+        if isinstance(value, int):
+            values.append(value)
+            continue
+        if isinstance(value, str) and value.isdigit():
+            values.append(int(value))
+
+    return max(values) if values else None
+
+
+def _get_capabilities(model: str, base_url: str | None = None) -> set[str]:
+    """Extract capabilities for a model (metadata is cached in _show_model)."""
+    response = _show_model(model, base_url)
+    payload = _response_field(response, "capabilities", {})
     if isinstance(payload, dict):
         payload = payload.get("capabilities", [])
 
@@ -35,17 +91,107 @@ def _get_capabilities(model: str) -> set[str]:
     return set()
 
 
-def model_supports_tools(model: str) -> bool:
+def model_supports_tools(model: str, base_url: str | None = None) -> bool:
     """Check if a model supports tool calls."""
-    return "tools" in _get_capabilities(model)
+    return "tools" in _get_capabilities(model, base_url)
 
 
-def ensure_model_supports_tools(model: str) -> None:
+def ensure_model_supports_tools(model: str, base_url: str | None = None) -> None:
     """Raise ModelCapabilityError if the model doesn't support tools."""
-    if not model_supports_tools(model):
+    if not model_supports_tools(model, base_url):
         raise ModelCapabilityError(f"Model '{model}' does not support tools.")
 
 
+def model_supports_thinking(model: str, base_url: str | None = None) -> bool:
+    """Best-effort detection of Ollama thinking support for a model."""
+    capabilities = _get_capabilities(model, base_url)
+    if "thinking" in capabilities:
+        return True
+
+    model_name = model.lower()
+    return any(model_name.startswith(prefix) for prefix in THINKING_MODEL_PREFIXES)
+
+
+def resolve_context_window(
+    model: str,
+    context_window: int | None,
+    base_url: str | None = None,
+) -> int:
+    """Resolve the effective context window for a model."""
+    if context_window is not None:
+        if context_window <= 0:
+            raise ModelContextWindowError("context_window must be greater than zero.")
+        return context_window
+
+    response = _show_model(model, base_url)
+    for field_name in ("modelfile", "parameters"):
+        if resolved := _parse_num_ctx(_response_field(response, field_name)):
+            return resolved
+
+    model_info = _response_field(response, "model_info", _response_field(response, "modelinfo", {}))
+    if resolved := _model_context_length(model_info):
+        return resolved
+
+    raise ModelContextWindowError(
+        f"Failed to determine the context window for '{model}'. "
+        "Define context_window in ~/.ollama-agent/config.ini."
+    )
+
+
+def resolve_ollama_reasoning(
+    model: str,
+    effort: ReasoningEffortValue,
+    base_url: str | None = None,
+    warn_callback: Callable[[str], None] | None = None,
+) -> bool | str | None:
+    """Translate reasoning_effort to Ollama's native reasoning setting."""
+    lower_name = model.lower()
+    if lower_name.startswith("gpt-oss"):
+        if effort == "disabled":
+            warning = (
+                "GPT-OSS does not support disabling thinking completely in Ollama; "
+                "continuing with the model default thinking behavior."
+            )
+            if warn_callback is not None:
+                warn_callback(warning)
+            return None
+        return effort
+
+    if not model_supports_thinking(model, base_url):
+        return None
+    return effort != "disabled"
+
+
+def create_ollama_chat_model(
+    *,
+    model: str,
+    base_url: str | None,
+    api_key: str | None,
+    context_window: int | None,
+    reasoning_effort: ReasoningEffortValue,
+    temperature: float = 0,
+    warn_callback: Callable[[str], None] | None = None,
+) -> ChatOllama:
+    """Create a native ChatOllama model with resolved runtime settings."""
+    host = (base_url or DEFAULT_BASE_URL).rstrip("/")
+    reasoning = resolve_ollama_reasoning(model, reasoning_effort, host, warn_callback)
+    num_ctx = resolve_context_window(model, context_window, host)
+
+    client_kwargs: dict[str, Any] = {}
+    if api_key and api_key != "ollama":
+        client_kwargs["headers"] = {"Authorization": f"Bearer {api_key}"}
+
+    kwargs: dict[str, Any] = {
+        "base_url": host,
+        "model": model,
+        "num_ctx": num_ctx,
+        "temperature": temperature,
+    }
+    if client_kwargs:
+        kwargs["client_kwargs"] = client_kwargs
+    if reasoning is not None:
+        kwargs["reasoning"] = reasoning
+    return ChatOllama(**kwargs)
 
 
 def validate_reasoning_effort(effort: str) -> ReasoningEffortValue:

--- a/ollama_agent/interfaces/model_commands.py
+++ b/ollama_agent/interfaces/model_commands.py
@@ -8,15 +8,21 @@ import ollama
 from rich.console import Console
 
 from ..core import ModelCapabilityError, model_supports_tools
+from ..settings import get_config
 
 if TYPE_CHECKING:
     from ..agent import OllamaAgent
 
 
+def _model_client(base_url: str) -> ollama.Client:
+    return ollama.Client(host=base_url)
+
+
 def list_models(console: Console, current_model: str) -> None:
     """Print available Ollama models with tool-support indicators."""
     try:
-        models = getattr(ollama.list(), "models", [])
+        cfg = get_config()
+        models = getattr(_model_client(cfg.base_url).list(), "models", [])
         if not models:
             console.print("[yellow]No models found in Ollama.[/yellow]")
             return
@@ -29,7 +35,7 @@ def list_models(console: Console, current_model: str) -> None:
             size_str = f"{size_gb:.1f}GB" if size_gb else ""
             try:
                 tool_icon = (
-                    "[green]✓[/green]" if model_supports_tools(name) else "[red]✗[/red]"
+                    "[green]✓[/green]" if model_supports_tools(name, cfg.base_url) else "[red]✗[/red]"
                 )
             except ModelCapabilityError:
                 tool_icon = "[yellow]?[/yellow]"
@@ -52,8 +58,10 @@ async def set_model(
 ) -> tuple[str, "OllamaAgent | None"]:
     """Switch to model_name, returning (new_model, new_agent)."""
     try:
+        cfg = get_config()
         available = {
-            getattr(model, "model", "") for model in getattr(ollama.list(), "models", [])
+            getattr(model, "model", "")
+            for model in getattr(_model_client(cfg.base_url).list(), "models", [])
         }
         if model_name not in available:
             console.print(
@@ -70,7 +78,7 @@ async def set_model(
         return current_model, active_agent
 
     try:
-        if not model_supports_tools(model_name):
+        if not model_supports_tools(model_name, cfg.base_url):
             console.print(
                 f"[red]Model '{model_name}' does not support tools.[/red]\n"
                 "[dim]The agent requires tool support.[/dim]"

--- a/ollama_agent/mcp/lifecycle.py
+++ b/ollama_agent/mcp/lifecycle.py
@@ -12,11 +12,16 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
-from langchain_openai import ChatOpenAI
 from langchain_core.tools import BaseTool, StructuredTool
 from langchain_mcp_adapters.tools import load_mcp_tools
 
-from ..core import ModelCapabilityError, ensure_model_supports_tools
+from ..core import (
+    ModelCapabilityError,
+    ReasoningEffortValue,
+    create_ollama_chat_model,
+    ensure_model_supports_tools,
+    validate_reasoning_effort,
+)
 from .types import DEFAULT_AGENT_INSTRUCTIONS, DEFAULT_MCP_CONFIG_PATH, RunningMCPServer
 
 logger = logging.getLogger(__name__)
@@ -141,7 +146,7 @@ async def _init_server(name: str, config: Any, default_model: str | None) -> Run
         return None
 
     try:
-        ensure_model_supports_tools(str(model))
+        ensure_model_supports_tools(str(model), config.get("base_url") or config.get("openai_api_base"))
     except ModelCapabilityError as exc:
         logger.error("Skipping MCP server '%s': %s", name, exc)
         return None
@@ -159,6 +164,13 @@ async def _init_server(name: str, config: Any, default_model: str | None) -> Run
     if not instructions:
         instructions = DEFAULT_AGENT_INSTRUCTIONS.format(name=name)
 
+    reasoning_effort = validate_reasoning_effort(
+        str(agent_cfg.get("reasoning_effort") or config.get("reasoning_effort") or "medium")
+    )
+
+    raw_context_window = agent_cfg.get("context_window", config.get("context_window"))
+    context_window = int(raw_context_window) if raw_context_window not in (None, "") else None
+
     try:
         # Use per-call MCP sessions instead of a shared long-lived session.
         # This avoids task-affinity/cancellation issues (AnyIO cancel scope
@@ -175,20 +187,22 @@ async def _init_server(name: str, config: Any, default_model: str | None) -> Run
         return None
 
     logger.info("Initialized MCP server: %s", name)
-    llm = ChatOpenAI(
-        **{
-            "model_name": str(model),
-            "openai_api_base": str(
-                config.get("base_url")
-                or config.get("openai_api_base")
-                or "http://localhost:11434/v1/"
-            ),
-            "openai_api_key": str(config.get("api_key") or config.get("openai_api_key") or "ollama"),
-            "temperature": 0,
-            "use_responses_api": False,
-            "streaming": False,
-        }
+    warnings: list[str] = []
+    llm = create_ollama_chat_model(
+        model=str(model),
+        base_url=str(
+            config.get("base_url")
+            or config.get("openai_api_base")
+            or "http://localhost:11434"
+        ),
+        api_key=str(config.get("api_key") or config.get("openai_api_key") or "ollama"),
+        context_window=context_window,
+        reasoning_effort=reasoning_effort,
+        temperature=0,
+        warn_callback=warnings.append,
     )
+    for warning in warnings:
+        logger.warning("MCP server '%s': %s", name, warning)
     return RunningMCPServer(
         name=name,
         subagent={
@@ -208,6 +222,8 @@ async def initialize_mcp_servers(
     default_model: str | None = None,
     base_url: str | None = None,
     api_key: str | None = None,
+    context_window: int | None = None,
+    reasoning_effort: ReasoningEffortValue = "medium",
 ) -> list[RunningMCPServer]:
     path = config_path or DEFAULT_MCP_CONFIG_PATH
     if not path.exists():
@@ -230,6 +246,10 @@ async def initialize_mcp_servers(
                 cfg = {**cfg, "base_url": base_url}
             if api_key and "api_key" not in cfg and "openai_api_key" not in cfg:
                 cfg = {**cfg, "api_key": api_key}
+            if context_window is not None and "context_window" not in cfg:
+                cfg = {**cfg, "context_window": context_window}
+            if reasoning_effort and "reasoning_effort" not in cfg:
+                cfg = {**cfg, "reasoning_effort": reasoning_effort}
         if s := await _init_server(str(name), cfg, default_model):
             servers.append(s)
     return servers

--- a/ollama_agent/settings/config.py
+++ b/ollama_agent/settings/config.py
@@ -28,9 +28,10 @@ def _default_instructions() -> str:
 class Config:
     """Application configuration."""
     model: str = "gpt-oss:20b"
-    base_url: str = "http://localhost:11434/v1/"
+    base_url: str = "http://localhost:11434"
     api_key: str = "ollama"
     reasoning_effort: str = "medium"
+    context_window: int | None = None
     database_path: Path = field(default_factory=lambda: DATABASE_PATH)
     builtin_tool_timeout: int = 30
     mcp_config_path: Path = field(default_factory=lambda: MCP_SERVERS_PATH)
@@ -92,6 +93,7 @@ def get_config(config_dir: Path | None = None) -> Config:
             "base_url": defaults.base_url,
             "api_key": defaults.api_key,
             "reasoning_effort": defaults.reasoning_effort,
+            "context_window": "" if defaults.context_window is None else str(defaults.context_window),
             "database_path": str(defaults.database_path),
             "builtin_tool_timeout": str(defaults.builtin_tool_timeout),
             "mcp_config_path": str(defaults.mcp_config_path),
@@ -109,11 +111,20 @@ def get_config(config_dir: Path | None = None) -> Config:
     mem0_section = dict(parser["mem0"]) if parser.has_section("mem0") else {}
     rag_section = dict(parser["rag"]) if parser.has_section("rag") else {}
 
+    base_url = section.get("base_url", defaults.base_url).rstrip("/")
+    if base_url.endswith("/v1"):
+        raise ValueError(
+            f"base_url '{base_url}' contains an '/v1' path from the old OpenAI-compatible "
+            "configuration. Update base_url to the native Ollama host "
+            f"(e.g. 'http://localhost:11434') in {config_path}."
+        )
+
     return Config(
         model=section.get("model", defaults.model),
-        base_url=section.get("base_url", defaults.base_url),
+        base_url=base_url,
         api_key=section.get("api_key", defaults.api_key),
         reasoning_effort=section.get("reasoning_effort", defaults.reasoning_effort),
+        context_window=_safe_cast(section.get("context_window"), int, defaults.context_window),
         database_path=Path(section.get("database_path", str(defaults.database_path))),
         builtin_tool_timeout=_safe_cast(section.get("builtin_tool_timeout"), int, defaults.builtin_tool_timeout),
         mcp_config_path=Path(section.get("mcp_config_path", str(defaults.mcp_config_path))),

--- a/ollama_agent/streaming/base.py
+++ b/ollama_agent/streaming/base.py
@@ -18,6 +18,10 @@ class StreamingRenderer(ABC):
         """Handle an error event."""
         print(f"Error: {event.get('content', 'Unknown error')}")
 
+    def on_warning(self, event: dict[str, Any]) -> None:
+        """Handle a warning event."""
+        print(f"Warning: {event.get('content', 'Unknown warning')}")
+
     @abstractmethod
     def close(self) -> None:
         """Clean up renderer resources."""

--- a/ollama_agent/streaming/console_renderer.py
+++ b/ollama_agent/streaming/console_renderer.py
@@ -71,6 +71,11 @@ class ConsoleStreamingRenderer(StreamingRenderer):
         self.console.print(
             f"\n[red]❌ Error: {event.get('content', 'Unknown error')}[/red]")
 
+    def on_warning(self, event: dict[str, Any]) -> None:
+        self._toggle_live(False)
+        self.console.print(
+            f"\n[yellow]⚠ Warning: {event.get('content', 'Unknown warning')}[/yellow]")
+
     def close(self) -> None:
         self._toggle_live(False)
         self.console.print()

--- a/ollama_agent/streaming/parsers.py
+++ b/ollama_agent/streaming/parsers.py
@@ -1,7 +1,7 @@
 """Streaming chunk parsers for LangChain / DeepAgents events.
 
 These functions extract structured text from the raw streaming payloads
-produced by :class:`~langchain_openai.ChatOpenAI` and DeepAgents, keeping
+produced by LangChain chat models and DeepAgents, keeping
 :mod:`~ollama_agent.agent.agent` focused solely on agent initialisation and
 workflow orchestration.
 """
@@ -33,13 +33,17 @@ def streaming_text(content: Any) -> str:
     return ""
 
 
-def streaming_reasoning(content: Any) -> str:
+def streaming_reasoning(content: Any, additional_kwargs: Any = None) -> str:
     """Extract reasoning/thinking text from a streaming chunk.
 
-    With ``use_responses_api=True`` reasoning tokens arrive as content blocks
-    of ``type='reasoning'`` whose text lives inside ``summary`` entries of
-    ``type='summary_text'``.
+    Supports both OpenAI-style reasoning blocks and ChatOllama's
+    ``additional_kwargs['reasoning_content']``.
     """
+    if isinstance(additional_kwargs, dict):
+        reasoning_content = additional_kwargs.get("reasoning_content")
+        if isinstance(reasoning_content, str):
+            return reasoning_content
+
     if not isinstance(content, list):
         return ""
     return "".join(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ollama-agent"
-version = "0.2.6"
+version = "0.3.0"
 description = "Agente de IA para interactuar con modelos de lenguaje locales a través de Ollama"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
     "deepagents==0.4.7",
     "langchain==1.2.10",
-    "langchain-openai==1.1.10",
+    "langchain-ollama==1.0.1",
     "langgraph==1.0.10",
     "langchain-mcp-adapters==0.2.1",
     "PyYAML==6.0.3",


### PR DESCRIPTION
## Summary

- migrate from the OpenAI-compatible Ollama path to native langchain-ollama integration
- resolve effective context window automatically from Ollama metadata or explicit config
- map reasoning effort to Ollama thinking support and surface warnings when needed
- reject legacy /v1 base_url configuration and require the native Ollama host
- bump application version to 0.3.0

## Validation

- python -m pytest -q
- 19 passed, 2 subtests passed