### PR TITLE
feat: add /mcps REPL command and improve MCP subagent tool visibility

### DIFF
--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -83,6 +83,10 @@ class OllamaAgent:
         return self._session_manager
 
     @property
+    def mcp_servers(self) -> list[RunningMCPServer]:
+        return self._mcp_servers
+
+    @property
     def rag_manager(self) -> RAGManager:
         return self._rag_manager
 

--- a/ollama_agent/interfaces/dispatch.py
+++ b/ollama_agent/interfaces/dispatch.py
@@ -11,6 +11,7 @@ from rich.markup import escape
 from rich.panel import Panel
 
 from ..agent import OllamaAgent
+from ..mcp import list_mcp_servers, show_mcp_server
 from ..rag import (
     RAGContext,
     add_rag_directory,
@@ -47,6 +48,7 @@ REPL_SECTIONS: tuple[str, ...] = (
     "Task Management",
     "RAG (Document Retrieval)",
     "Skills Management",
+    "MCP Servers",
 )
 
 
@@ -146,6 +148,12 @@ def build_repl_handlers(
         "/skill-delete": REPLCommand("Delete a skill", "Skills Management", "/skill-delete <id>", lambda args: delete_skill(skills_ctx, args[0])),
         "/task-create": REPLCommand("Create a task", "Task Management", "/task-create <id> [--force]", lambda _: None),
         "/skill-create": REPLCommand("Create a skill", "Skills Management", "/skill-create <id> [--force]", lambda _: None),
+        "/mcps": REPLCommand(
+            "List MCP server connection status",
+            "MCP Servers",
+            "/mcps [name]",
+            lambda args: show_mcp_server(console, ensure_agent(), args[0]) if args else list_mcp_servers(console, ensure_agent()),
+        ),
     }
 
 

--- a/ollama_agent/mcp/__init__.py
+++ b/ollama_agent/mcp/__init__.py
@@ -1,5 +1,6 @@
 """MCP servers configuration and lifecycle management."""
 
+from .commands import list_mcp_servers, show_mcp_server
 from .lifecycle import cleanup_mcp_servers, initialize_mcp_servers
 from .types import RunningMCPServer
 
@@ -7,4 +8,6 @@ __all__ = [
     "RunningMCPServer",
     "cleanup_mcp_servers",
     "initialize_mcp_servers",
+    "list_mcp_servers",
+    "show_mcp_server",
 ]

--- a/ollama_agent/mcp/commands.py
+++ b/ollama_agent/mcp/commands.py
@@ -1,0 +1,87 @@
+"""MCP server status commands for CLI and REPL."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from rich.console import Console
+from rich.table import Table
+
+from .lifecycle import _infer_transport
+from .types import DEFAULT_MCP_CONFIG_PATH
+
+if TYPE_CHECKING:
+    from ..agent import OllamaAgent
+
+logger = logging.getLogger(__name__)
+
+
+async def list_mcp_servers(console: Console, agent: OllamaAgent) -> None:
+    """Display connection status and tool counts for configured MCP servers."""
+    await agent.initialize()
+
+    config_path = agent.mcp_config_path or DEFAULT_MCP_CONFIG_PATH
+    if not config_path.exists():
+        console.print("[yellow]No MCP servers configured.[/yellow]")
+        return
+
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        console.print(f"[red]Failed to read MCP config: {exc}[/red]")
+        return
+
+    servers_cfg: dict[str, Any] = data.get("mcpServers", {})
+    if not isinstance(servers_cfg, dict) or not servers_cfg:
+        console.print("[yellow]No MCP servers configured.[/yellow]")
+        return
+
+    running = {srv.name: srv for srv in agent.mcp_servers}
+
+    table = Table(title="MCP Servers", show_header=True, header_style="bold magenta")
+    table.add_column("Name", style="cyan")
+    table.add_column("Transport")
+    table.add_column("Status")
+    table.add_column("Tools", style="magenta", justify="right")
+
+    for name, cfg in servers_cfg.items():
+        transport = _infer_transport(cfg) if isinstance(cfg, dict) else "?"
+        if name in running:
+            status = "[green]Connected[/green]"
+            tools = str(len(running[name].subagent.get("tools", [])))
+        else:
+            status = "[red]Error[/red]"
+            tools = "-"
+        table.add_row(name, transport, status, tools)
+
+    console.print(table)
+
+
+async def show_mcp_server(console: Console, agent: OllamaAgent, name: str) -> None:
+    """Display the tools available for a specific MCP server."""
+    await agent.initialize()
+
+    running = {srv.name: srv for srv in agent.mcp_servers}
+    if name not in running:
+        console.print(f"[red]MCP server not found or not connected:[/red] {name}")
+        return
+
+    tools = running[name].subagent.get("tools", [])
+    if not tools:
+        console.print(f"[yellow]No tools available for MCP server:[/yellow] {name}")
+        return
+
+    table = Table(title=f"MCP Server: {name}", show_header=True, header_style="bold magenta")
+    table.add_column("Tool", style="cyan")
+    table.add_column("Description")
+
+    max_desc = 80
+    for tool in tools:
+        desc = (tool.description or "").replace("\n", " ").strip()
+        if len(desc) > max_desc:
+            desc = desc[:max_desc] + "..."
+        table.add_row(tool.name, desc)
+
+    console.print(table)

--- a/ollama_agent/mcp/lifecycle.py
+++ b/ollama_agent/mcp/lifecycle.py
@@ -203,11 +203,16 @@ async def _init_server(name: str, config: Any, default_model: str | None) -> Run
     )
     for warning in warnings:
         logger.warning("MCP server '%s': %s", name, warning)
+    tool_names = ", ".join(t.name for t in mcp_tools)
+    enhanced_description = (
+        f"{subagent_description} (Tools: {tool_names})"
+        if mcp_tools else subagent_description
+    )
     return RunningMCPServer(
         name=name,
         subagent={
             "name": subagent_name,
-            "description": subagent_description,
+            "description": enhanced_description,
             "system_prompt": instructions,
             "tools": mcp_tools,
             "model": llm,


### PR DESCRIPTION
## Summary

- Add `/mcps` REPL command that displays a table of all configured MCP servers with their connection status (Connected/Error), transport type, and tool count
- Add `/mcps <name>` variant that lists all tools available on a specific MCP server with descriptions
- Enrich MCP subagent descriptions with tool names so the main agent can see what tools each subagent provides and delegate to them appropriately
- Add `mcp_servers` property to `OllamaAgent` for public read access to running MCP servers

## Test plan

- [x] Run `ollama-agent` and type `/help` — confirm "MCP Servers" section appears with `/mcps` listed
- [x] Type `/mcps` — confirm table shows all configured servers with status and tool counts
- [x] Type `/mcps <server_name>` — confirm tool names and descriptions are listed for that server
- [x] Ask the agent about a specific MCP tool — confirm it now recognizes it can delegate to the appropriate subagent
- [x] Verify behavior when no `mcp_servers.json` exists (should show "No MCP servers configured")

	🤖 Generated with [Qoder][https://qoder.com]