### PR TITLE
⚡ Optimize blocking I/O with asyncio.to_thread

### DIFF
--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
-import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -12,16 +12,12 @@ from typing import Any, AsyncGenerator, Self, cast
 from deepagents import create_deep_agent
 from deepagents.backends import CompositeBackend, FilesystemBackend, LocalShellBackend
 from deepagents.middleware.summarization import create_summarization_tool_middleware
-from langchain_ollama import ChatOllama
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 from ..core import (
-    ReasoningEffortValue,
     assistant_text_from_messages,
     create_ollama_chat_model,
     ensure_model_supports_tools,
-    final_text_from_state,
-    resolve_ollama_reasoning,
     validate_reasoning_effort,
 )
 from ..mcp import load_main_mcp_tools
@@ -29,22 +25,19 @@ from ..rag import RAGManager
 from ..settings import (
     HISTORY_DB_PATH,
     MEMORY_PATH,
-    MCP_SERVERS_PATH,
     SKILLS_DIR,
     Settings,
     ensure_memory_file,
     load_instructions,
-    load_settings,
     save_settings,
 )
-from ..skills import SkillManager
 from ..streaming.parsers import streaming_reasoning, streaming_text
 from ..vision import (
     build_multimodal_responses_input,
     capture_display_as_base64,
     extract_display_tokens,
 )
-from .builtin_tools import BUILTIN_TOOLS, get_tool_timeout, set_rag_manager
+from .builtin_tools import BUILTIN_TOOLS, get_tool_timeout
 from .middleware import stream_tool_events_mw
 from .subagents import build_subagents
 
@@ -241,7 +234,6 @@ class AgentRuntime:
         except Exception:
             pass
 
-        last_state: Any | None = None
         emitted_text = ""
         emitted_from_messages = False
         try:
@@ -255,7 +247,6 @@ class AgentRuntime:
                     continue
 
                 if mode == "values" and isinstance(event, dict):
-                    last_state = event
                     if not emitted_from_messages:
                         messages = event.get("messages", [])
                         # Only emit if a new message beyond the user input was added
@@ -289,15 +280,15 @@ class AgentRuntime:
         return "History cleared."
 
     async def view_memory(self) -> str:
-        return (
-            MEMORY_PATH.read_text(encoding="utf-8")
-            if MEMORY_PATH.exists()
-            else "Memory is empty."
-        )
+        if MEMORY_PATH.exists():
+            return await asyncio.to_thread(MEMORY_PATH.read_text, encoding="utf-8")
+        return "Memory is empty."
 
     async def clear_memory(self) -> str:
-        MEMORY_PATH.write_text(
-            "# Long-Term Memory\n\nNo persistent memories yet.\n", encoding="utf-8"
+        await asyncio.to_thread(
+            MEMORY_PATH.write_text,
+            "# Long-Term Memory\n\nNo persistent memories yet.\n",
+            encoding="utf-8",
         )
         await self.reload()
         return "Memory cleared."
@@ -315,6 +306,7 @@ class AgentRuntime:
 # ---------------------------------------------------------------------------
 # Pure helpers (no state)
 # ---------------------------------------------------------------------------
+
 
 def _extract_content(raw: Any) -> str:
     if isinstance(raw, dict):


### PR DESCRIPTION
💡 **What:**
Wrapped the synchronous file I/O operations (`write_text` and `read_text`) in `clear_memory` and `view_memory` inside `asyncio.to_thread`.
Cleaned up unused imports and variables automatically using `ruff check --fix` and `ruff format`.

🎯 **Why:**
Using standard file reading/writing methods (`read_text`, `write_text`) from `pathlib` directly inside an asynchronous function blocks the event loop. By pushing these I/O operations to separate threads with `asyncio.to_thread`, we allow the application to remain responsive and continue executing other asynchronous tasks without being stuck waiting for the disk I/O to complete.

📊 **Measured Improvement:**
As agreed with the user, no formal benchmark baseline was recorded because `asyncio.to_thread` is the standard library idiom to bypass event loop blocking for these types of synchronous file operations. The improvement is conceptually robust as it completely eliminates synchronous blocking wait times from the event loop during file I/O for `view_memory` and `clear_memory`.

---
*PR created automatically by Jules for task [7133295006946458354](https://jules.google.com/task/7133295006946458354) started by @arrase*