### PR TITLE
Add hide and enabled reasoning effort options

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,11 @@ ollama-agent -m "gpt-oss:20b" -e "high" -p "What is the current date?"
 | Model family | `--effort` value | Ollama `think` value | Behaviour |
 |---|---|---|---|
 | **GPT-OSS** | `low` / `medium` / `high` | `"low"` / `"medium"` / `"high"` | Sets the thinking trace length. GPT-OSS only accepts these levels; `true`/`false` is ignored. |
-| **GPT-OSS** | `disabled` | *(not sent)* | GPT-OSS cannot fully disable thinking — a warning is emitted and the model uses its default behaviour. |
-| **Other thinking models** (Qwen 3, DeepSeek R1, DeepSeek-v3.1, …) | any except `disabled` | `true` | Enables thinking. |
-| **Other thinking models** | `disabled` | `false` | Disables thinking. |
+| **GPT-OSS** | `disabled` / `hide` | *(not sent)* | GPT-OSS cannot fully disable thinking. For `disabled`, a warning is emitted and the default level is used. In both cases, the thinking trace is hidden from the UI. |
+| **GPT-OSS** | `enabled` | `"medium"` | Enables thinking using the default `medium` effort level. |
+| **Other thinking models** (Qwen 3, DeepSeek R1, DeepSeek-v3.1, …) | `low` / `medium` / `high` / `enabled` | `true` | Enables thinking. The specific levels are ignored by Ollama but turn on thinking. |
+| **Other thinking models** | `hide` | `true` | The model generates the reasoning trace, but it is hidden from the UI output. |
+| **Other thinking models** | `disabled` | `false` | Disables thinking at the model level. |
 | **Non-thinking models** | *(any)* | *(not sent)* | Setting is ignored. |
 
 Thinking is enabled by default in Ollama for supported models. See the [Ollama thinking docs](https://docs.ollama.com/capabilities/thinking) for the full list of supported models and API details.
@@ -149,7 +151,7 @@ ollama-agent -t 60 -p "Run a long-running task"
 
 - `-m`, `--model`: Specify the AI model to use
 - `-p`, `--prompt`: Provide a prompt for non-interactive mode
-- `-e`, `--effort`: Set reasoning effort level (low, medium, high, disabled)
+- `-e`, `--effort`: Set reasoning effort level (low, medium, high, disabled, hide, enabled)
 - `-t`, `--builtin-tool-timeout`: Set tool-call timeout in seconds (applies to tool executions, including shell backend and built-in tools). Overrides `builtin_tool_timeout` from `config.ini` for the current run.
 - `--rag <database>`: Load a RAG database for the session
 - `--skills-dir <dir>`: Additional skills directory (can be repeated to add multiple sources)
@@ -194,7 +196,7 @@ Example:
 title: "List repo tree"
 prompt: "List all files in this repository as a tree."
 model: "gpt-oss:20b"
-reasoning_effort: "medium"  # low|medium|high|disabled
+reasoning_effort: "medium"  # low|medium|high|disabled|hide|enabled
 ```
 
 **List Tasks:**
@@ -250,7 +252,7 @@ rag:
 |---|---|
 | `model.name` | Default Ollama model. Must support tool calling. |
 | `model.base_url` | Native Ollama host (e.g. `http://localhost:11434`). Must **not** contain an `/v1` path. |
-| `model.reasoning_effort` | Default thinking level: `low`, `medium`, `high`, or `disabled`. See [Thinking / Reasoning](#common-options) above. |
+| `model.reasoning_effort` | Default thinking level: `low`, `medium`, `high`, `disabled`, `hide`, or `enabled`. See [Thinking / Reasoning](#common-options) above. |
 | `model.context_window` | If set, forces the runtime `num_ctx` for the selected model. Leave `null` to let the app resolve it automatically. |
 | `runtime.builtin_tool_timeout` | Timeout in seconds for tool executions. |
 

--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -198,6 +198,8 @@ class AgentRuntime:
         config = {"configurable": {"thread_id": thread}}
         user_msg = _maybe_attach_screen_context(prompt)
 
+        hide_reasoning = self.settings.model.reasoning_effort in ("hide", "disabled")
+
         try:
             async for mode, event in self.graph.astream(
                 {"messages": [user_msg]},
@@ -210,7 +212,9 @@ class AgentRuntime:
 
                 if mode == "messages":
                     chunk = event[0] if isinstance(event, tuple) and event else event
-                    result = _process_message_chunk(chunk)
+                    result = _process_message_chunk(
+                        chunk, hide_reasoning=hide_reasoning
+                    )
                     if result:
                         yield result
         except Exception as exc:
@@ -232,7 +236,10 @@ class AgentRuntime:
 # ---------------------------------------------------------------------------
 
 
-def _process_message_chunk(chunk: Any) -> dict[str, Any] | None:
+def _process_message_chunk(
+    chunk: Any,
+    hide_reasoning: bool = False,
+) -> dict[str, Any] | None:
     """Process 'messages' chunk to extract reasoning or text deltas."""
     chunk_type = str(getattr(chunk, "type", "") or "").lower()
     chunk_name = getattr(chunk, "__class__", type(chunk)).__name__.lower()
@@ -244,6 +251,8 @@ def _process_message_chunk(chunk: Any) -> dict[str, Any] | None:
 
     reasoning = streaming_reasoning(content, additional_kwargs)
     if reasoning:
+        if hide_reasoning:
+            return None
         return {"type": "reasoning_delta", "content": reasoning}
 
     text = streaming_text(content)

--- a/ollama_agent/core/common.py
+++ b/ollama_agent/core/common.py
@@ -4,12 +4,14 @@ import re
 from typing import Any, Literal, TypedDict
 
 # Reasoning effort types
-ReasoningEffortValue = Literal["low", "medium", "high", "disabled"]
+ReasoningEffortValue = Literal["low", "medium", "high", "disabled", "hide", "enabled"]
 ALLOWED_REASONING_EFFORTS: tuple[ReasoningEffortValue, ...] = (
     "low",
     "medium",
     "high",
     "disabled",
+    "hide",
+    "enabled",
 )
 DEFAULT_REASONING_EFFORT: ReasoningEffortValue = "medium"
 

--- a/ollama_agent/core/models.py
+++ b/ollama_agent/core/models.py
@@ -149,18 +149,24 @@ async def resolve_ollama_reasoning(
     """Translate reasoning_effort to Ollama's native reasoning setting."""
     lower_name = model.lower()
     if lower_name.startswith("gpt-oss"):
-        if effort == "disabled":
-            warning = (
-                "GPT-OSS does not support disabling thinking completely in Ollama; "
-                "continuing with the model default thinking behavior."
-            )
-            if warn_callback is not None:
-                warn_callback(warning)
+        if effort in ("disabled", "hide"):
+            if effort == "disabled":
+                warning = (
+                    "GPT-OSS does not support disabling thinking completely in Ollama; "
+                    "continuing with the model default thinking behavior, but it will be hidden."
+                )
+                if warn_callback is not None:
+                    warn_callback(warning)
             return None
+        if effort == "enabled":
+            return DEFAULT_REASONING_EFFORT
         return effort
 
     if not await model_supports_thinking(model, base_url):
         return None
+
+    if effort in ("hide", "enabled"):
+        return True
     return effort != "disabled"
 
 
@@ -175,7 +181,9 @@ async def create_ollama_chat_model(
 ) -> ChatOllama:
     """Create a native ChatOllama model with resolved runtime settings."""
     host = (base_url or DEFAULT_BASE_URL).rstrip("/")
-    reasoning = await resolve_ollama_reasoning(model, reasoning_effort, host, warn_callback)
+    reasoning = await resolve_ollama_reasoning(
+        model, reasoning_effort, host, warn_callback
+    )
     num_ctx = await resolve_context_window(model, context_window, host)
 
     kwargs: dict[str, Any] = {

--- a/ollama_agent/interfaces/cli.py
+++ b/ollama_agent/interfaces/cli.py
@@ -27,7 +27,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         "--effort",
         type=str,
         choices=list(ALLOWED_REASONING_EFFORTS),
-        help="Set reasoning effort level (low, medium, high, disabled)",
+        help="Set reasoning effort level (low, medium, high, disabled, hide, enabled)",
     )
     parser.add_argument(
         "-t",
@@ -86,7 +86,7 @@ def _add_task_subcommands(parser: argparse.ArgumentParser) -> None:
         type=str,
         choices=list(ALLOWED_REASONING_EFFORTS),
         required=False,
-        help="Reasoning effort to save with the task",
+        help="Reasoning effort to save with the task (low, medium, high, disabled, hide, enabled)",
     )
     task_create.add_argument(
         "--force", action="store_true", help="Overwrite task if it already exists"
@@ -156,7 +156,9 @@ def create_argument_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def handle_cli_commands(args: argparse.Namespace, settings: Settings | None = None) -> bool:
+def handle_cli_commands(
+    args: argparse.Namespace, settings: Settings | None = None
+) -> bool:
     """Handle CLI commands and return True if a command was handled."""
     if settings is None:
         settings = load_settings()

--- a/ollama_agent/interfaces/model_commands.py
+++ b/ollama_agent/interfaces/model_commands.py
@@ -65,8 +65,7 @@ async def set_model(
         settings = load_settings()
         base_url = settings.model.base_url
         available = {
-            getattr(model, "model", "")
-            for model in await _list_models(base_url)
+            getattr(model, "model", "") for model in await _list_models(base_url)
         }
         if model_name not in available:
             console.print(

--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -135,16 +135,20 @@ class OllamaREPL:
         # Dispatch to registered handlers (excludes inline-handled commands)
         _INLINE = {"/exit", "/quit", "/clear", "/new", "/task-create", "/skill-create"}
         if cmd in commands and cmd not in _INLINE:
-            if cmd in {
-                "/task-run",
-                "/task-delete",
-                "/model-set",
-                "/rag-create",
-                "/rag-delete",
-                "/rag-load",
-                "/skill-show",
-                "/skill-delete",
-            } and not args:
+            if (
+                cmd
+                in {
+                    "/task-run",
+                    "/task-delete",
+                    "/model-set",
+                    "/rag-create",
+                    "/rag-delete",
+                    "/rag-load",
+                    "/skill-show",
+                    "/skill-delete",
+                }
+                and not args
+            ):
                 self.console.print(f"[red]Usage: {cmd} <value>[/red]")
                 return
             if cmd == "/rag-add" and not args:

--- a/ollama_agent/rag/commands.py
+++ b/ollama_agent/rag/commands.py
@@ -26,8 +26,11 @@ class RAGContext:
         if resolved := resolve_unique_prefix(name, names):
             return resolved
         matches = [c for c in names if c.startswith((name or "").strip())]
-        msg = (f"Database not found: {name}" if not matches
-               else f"Ambiguous prefix: {name} -> {', '.join(matches)}")
+        msg = (
+            f"Database not found: {name}"
+            if not matches
+            else f"Ambiguous prefix: {name} -> {', '.join(matches)}"
+        )
         self.console.print(f"[red]{msg}[/red]")
         raise SystemExit(1)
 

--- a/ollama_agent/rag/manager.py
+++ b/ollama_agent/rag/manager.py
@@ -360,7 +360,9 @@ class RAGManager:
 
         return results
 
-    async def search(self, query: str, top_k: int | None = None) -> list[dict[str, Any]]:
+    async def search(
+        self, query: str, top_k: int | None = None
+    ) -> list[dict[str, Any]]:
         """Search the RAG database for relevant documents."""
         client = self._ensure_loaded()
         top_k = top_k or self.settings.default_top_k


### PR DESCRIPTION
Added support for new reasoning effort options "hide" and "enabled" to better control thinking model trace streams. Updates the `ReasoningEffortValue` type, the Ollama payload mappings in `resolve_ollama_reasoning`, the text streaming filter to hide UI output on demand, the CLI arg helps, and README documentation.

---
*PR created automatically by Jules for task [1527251769443489122](https://jules.google.com/task/1527251769443489122) started by @arrase*