### PR TITLE
fix: route project workspace to /workspace/ in virtual filesystem

### DIFF
--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, AsyncGenerator, Self, cast
 
 from deepagents import create_deep_agent
-from deepagents.backends import CompositeBackend, FilesystemBackend, LocalShellBackend
+from deepagents.backends import CompositeBackend, FilesystemBackend, LocalShellBackend, StateBackend
 from deepagents.middleware.summarization import create_summarization_tool_middleware
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.types import Command
@@ -99,7 +99,8 @@ class AgentRuntime:
 
         # Backend: CWD for shell + APP_DIR for agent files (memory, etc.)
         timeout = int(get_tool_timeout())
-        default_backend = LocalShellBackend(
+        default_backend = StateBackend()
+        workspace_backend = LocalShellBackend(
             root_dir=Path.cwd(),
             timeout=timeout,
             virtual_mode=not self.settings.runtime.allow_traversal,
@@ -117,6 +118,7 @@ class AgentRuntime:
             routes={
                 "/agent/": agent_backend,
                 "/skills/": skills_backend,
+                "/workspace/": workspace_backend,
             },
         )
 

--- a/ollama_agent/settings/default_instructions.md
+++ b/ollama_agent/settings/default_instructions.md
@@ -3,6 +3,11 @@ You are an AI Assistant.
 # CORE OBJECTIVE
 Solve the user's task efficiently and transparently. Prefer tool use over guessing when external actions, shell inspection, or past memory are needed.
 
+# WORKSPACE POLICY
+The user's project files and current directory are mounted under the `/workspace/` virtual directory (e.g., `/workspace/README.md`).
+Always use filesystem tools (`ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`) on `/workspace/` to interact with the project workspace.
+Do NOT mix project workspace files with agent-internal files located under `/agent/` or `/skills/`.
+
 # MEMORY POLICY
 You have a persistent memory file at `/agent/MEMORY.md`. Use your filesystem tools (`read_file`, `write_file`, `edit_file`) to manage it.
 


### PR DESCRIPTION
Isolates the project directory under /workspace/ instead of the virtual root / to resolve agent confusion and prevent internal file pollution.