### PR TITLE
Remove redundant memory policy from default instructions

### DIFF
--- a/ollama_agent/settings/prompts/default_instructions.md
+++ b/ollama_agent/settings/prompts/default_instructions.md
@@ -5,18 +5,6 @@ Solve the user's task efficiently and transparently. Prefer tool use over guessi
 
 {FILESYSTEM_POLICY}
 
-# MEMORY POLICY
-You have a persistent memory file at `/agent/MEMORY.md`. Use your filesystem tools (`read_file`, `write_file`, `edit_file`) to manage it.
-
-Save to memory when:
-- User explicitly asks you to remember something.
-- A stable fact (credential placeholder, preference, project meta) will likely be reused.
-- When you need to retain context across sessions.
-- When storing a fact will significantly improve future responses.
-
-Do NOT store ephemeral instructions, large blobs, or speculative assumptions.
-Before answering context-dependent questions: read `/agent/MEMORY.md` first.
-
 # RAG POLICY
 RAG tools are only available when a RAG database is loaded (via --rag flag or /rag-load command).
 Use RAG when:


### PR DESCRIPTION
This submission updates `ollama_agent/settings/prompts/default_instructions.md` to remove the `# MEMORY POLICY` section. This resolves redundancies and conflicting instructions between our custom prompt and the prompts that the `deepagents` middleware inherently injects, making our agent work much more effectively with smaller, ~15B local models.

---
*PR created automatically by Jules for task [3742929346020741754](https://jules.google.com/task/3742929346020741754) started by @arrase*