### PR TITLE
fix: integrate native OS clipboard and auto-copy on text selection in…

### DIFF
--- a/ollama_agent/interfaces/clipboard.py
+++ b/ollama_agent/interfaces/clipboard.py
@@ -1,0 +1,99 @@
+"""System clipboard integration utilities for macOS, Linux, and Windows."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+def copy_to_system_clipboard(text: str) -> None:
+    """Copy text to the OS system clipboard using native platform tools."""
+    if sys.platform == "darwin":
+        subprocess.run(
+            ["pbcopy"],
+            input=text.encode("utf-8"),
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    elif sys.platform.startswith(("linux", "freebsd", "openbsd")):
+        if os.environ.get("WAYLAND_DISPLAY") and shutil.which("wl-copy"):
+            subprocess.run(
+                ["wl-copy"],
+                input=text.encode("utf-8"),
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        elif shutil.which("xclip"):
+            subprocess.run(
+                ["xclip", "-selection", "clipboard"],
+                input=text.encode("utf-8"),
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        elif shutil.which("xsel"):
+            subprocess.run(
+                ["xsel", "--clipboard", "--input"],
+                input=text.encode("utf-8"),
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+    elif sys.platform == "win32":
+        subprocess.run(
+            ["clip"],
+            input=text.encode("utf-16"),
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+
+def get_system_clipboard() -> str:
+    """Retrieve text from the OS system clipboard."""
+    if sys.platform == "darwin":
+        proc = subprocess.run(
+            ["pbpaste"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return proc.stdout
+    elif sys.platform.startswith(("linux", "freebsd", "openbsd")):
+        if os.environ.get("WAYLAND_DISPLAY") and shutil.which("wl-paste"):
+            proc = subprocess.run(
+                ["wl-paste", "--no-newline"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            return proc.stdout
+        elif shutil.which("xclip"):
+            proc = subprocess.run(
+                ["xclip", "-selection", "clipboard", "-o"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            return proc.stdout
+        elif shutil.which("xsel"):
+            proc = subprocess.run(
+                ["xsel", "--clipboard", "--output"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            return proc.stdout
+    elif sys.platform == "win32":
+        proc = subprocess.run(
+            ["powershell", "-command", "Get-Clipboard"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return proc.stdout.rstrip("\r\n")
+    return ""

--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -9,6 +9,7 @@ from typing import Any
 from rich.console import Console
 from rich.text import Text
 
+from textual import events
 from textual.app import App, ComposeResult
 from textual.worker import Worker
 from textual.containers import ScrollableContainer, Horizontal
@@ -16,6 +17,7 @@ from textual.widgets import Static, OptionList, TextArea
 from textual.widgets.option_list import Option
 from langgraph.types import Command
 
+from .clipboard import copy_to_system_clipboard, get_system_clipboard
 from .tui_components import (
     AgentHeader,
     ReplInput,
@@ -118,8 +120,10 @@ class OllamaAgentApp(App):
     BINDINGS = [
         ("escape", "cancel_generation", "Interrupt"),
         ("ctrl+c", "cancel_or_quit", "Interrupt/Quit"),
+        ("super+c", "copy_selection", "Copy"),
+        ("ctrl+shift+c", "copy_selection", "Copy"),
+        ("ctrl+insert", "copy_selection", "Copy"),
     ]
-
 
     def action_cancel_generation(self) -> None:
         if self._is_generating and self._current_worker is not None:
@@ -131,6 +135,27 @@ class OllamaAgentApp(App):
                 self._current_worker.cancel()
         else:
             self.exit()
+
+    def action_copy_selection(self) -> None:
+        selected_text = self.screen.get_selected_text()
+        if selected_text:
+            self.copy_to_clipboard(selected_text)
+
+    def copy_to_clipboard(self, text: str) -> None:
+        super().copy_to_clipboard(text)
+        copy_to_system_clipboard(text)
+
+    @property
+    def clipboard(self) -> str:
+        sys_clip = get_system_clipboard()
+        if sys_clip:
+            return sys_clip
+        return super().clipboard
+
+    def on_text_selected(self, event: events.TextSelected) -> None:
+        selected_text = self.screen.get_selected_text()
+        if selected_text:
+            self.copy_to_clipboard(selected_text)
 
     CSS_PATH = "repl.css"
 

--- a/ollama_agent/interfaces/tui_components.py
+++ b/ollama_agent/interfaces/tui_components.py
@@ -49,6 +49,10 @@ class AgentHeader(Static):
 class ReplInput(TextArea):
     """Interactive input field that captures Tab/arrow keys for autocomplete."""
 
+    BINDINGS = [
+        ("super+v", "paste", "Paste"),
+    ]
+
     def __init__(self, **kwargs: Any):
         kwargs.setdefault("highlight_cursor_line", False)
         super().__init__(**kwargs)

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from textual import events
+
+from ollama_agent.interfaces.clipboard import copy_to_system_clipboard, get_system_clipboard
+from ollama_agent.interfaces.repl import OllamaAgentApp, OllamaREPL
+from ollama_agent.interfaces.tui_components import ReplInput, UserMessage
+
+
+class TestClipboard(unittest.TestCase):
+    """Unit tests for system clipboard utilities."""
+
+    @patch("sys.platform", "darwin")
+    @patch("subprocess.run")
+    def test_copy_darwin(self, mock_run: MagicMock) -> None:
+        copy_to_system_clipboard("hello mac")
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        self.assertEqual(args[0], ["pbcopy"])
+        self.assertEqual(kwargs["input"], b"hello mac")
+
+    @patch("sys.platform", "linux")
+    @patch("shutil.which", side_effect=lambda cmd: "/usr/bin/wl-copy" if cmd == "wl-copy" else None)
+    @patch.dict("os.environ", {"WAYLAND_DISPLAY": "wayland-0"})
+    @patch("subprocess.run")
+    def test_copy_linux_wayland(self, mock_run: MagicMock, mock_which: MagicMock) -> None:
+        copy_to_system_clipboard("hello wayland")
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        self.assertEqual(args[0], ["wl-copy"])
+        self.assertEqual(kwargs["input"], b"hello wayland")
+
+    @patch("sys.platform", "linux")
+    @patch("shutil.which", side_effect=lambda cmd: "/usr/bin/xclip" if cmd == "xclip" else None)
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("subprocess.run")
+    def test_copy_linux_xclip(self, mock_run: MagicMock, mock_which: MagicMock) -> None:
+        copy_to_system_clipboard("hello xclip")
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        self.assertEqual(args[0], ["xclip", "-selection", "clipboard"])
+        self.assertEqual(kwargs["input"], b"hello xclip")
+
+    @patch("sys.platform", "win32")
+    @patch("subprocess.run")
+    def test_copy_win32(self, mock_run: MagicMock) -> None:
+        copy_to_system_clipboard("hello windows")
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        self.assertEqual(args[0], ["clip"])
+        self.assertEqual(kwargs["input"], "hello windows".encode("utf-16"))
+
+    @patch("sys.platform", "darwin")
+    @patch("subprocess.run")
+    def test_get_clipboard_darwin(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(stdout="mac clipboard content")
+        res = get_system_clipboard()
+        self.assertEqual(res, "mac clipboard content")
+        mock_run.assert_called_once()
+        args, _ = mock_run.call_args
+        self.assertEqual(args[0], ["pbpaste"])
+
+
+class TestAppClipboardIntegration(unittest.IsolatedAsyncioTestCase):
+    """Integration tests for OllamaAgentApp selection and clipboard features."""
+
+    async def test_app_copy_to_clipboard_invokes_system_copy(self) -> None:
+        repl_mock = MagicMock(spec=OllamaREPL)
+        repl_mock.runtime = MagicMock()
+        repl_mock.runtime.yolo_mode = False
+        repl_mock._rag_ctx = None
+        repl_mock.runtime.settings.model.name = "gemma4:26b"
+        repl_mock.runtime.settings.model.reasoning_effort = "medium"
+
+        app = OllamaAgentApp(repl_mock)
+        with patch("ollama_agent.interfaces.repl.copy_to_system_clipboard") as mock_sys_copy:
+            async with app.run_test() as pilot:
+                app.copy_to_clipboard("test copy content")
+                mock_sys_copy.assert_called_once_with("test copy content")
+                self.assertEqual(app._clipboard, "test copy content")
+
+    async def test_text_selected_auto_copies(self) -> None:
+        repl_mock = MagicMock(spec=OllamaREPL)
+        repl_mock.runtime = MagicMock()
+        repl_mock.runtime.yolo_mode = False
+        repl_mock._rag_ctx = None
+        repl_mock.runtime.settings.model.name = "gemma4:26b"
+        repl_mock.runtime.settings.model.reasoning_effort = "medium"
+
+        app = OllamaAgentApp(repl_mock)
+        with patch("ollama_agent.interfaces.repl.copy_to_system_clipboard") as mock_sys_copy:
+            async with app.run_test() as pilot:
+                chat_scroll = app.query_one("#chat-scroll")
+                msg = UserMessage("Selectable text here")
+                await chat_scroll.mount(msg)
+                await pilot.pause()
+
+                app.screen.text_select_all()
+                app.on_text_selected(events.TextSelected())
+                self.assertTrue(mock_sys_copy.called)
+                copied_arg = mock_sys_copy.call_args[0][0]
+                self.assertIn("Selectable text here", copied_arg)
+
+    async def test_action_copy_selection(self) -> None:
+        repl_mock = MagicMock(spec=OllamaREPL)
+        repl_mock.runtime = MagicMock()
+        repl_mock.runtime.yolo_mode = False
+        repl_mock._rag_ctx = None
+        repl_mock.runtime.settings.model.name = "gemma4:26b"
+        repl_mock.runtime.settings.model.reasoning_effort = "medium"
+
+        app = OllamaAgentApp(repl_mock)
+        with patch("ollama_agent.interfaces.repl.copy_to_system_clipboard") as mock_sys_copy:
+            async with app.run_test() as pilot:
+                chat_scroll = app.query_one("#chat-scroll")
+                msg = UserMessage("Copy action message")
+                await chat_scroll.mount(msg)
+                await pilot.pause()
+
+                app.screen.text_select_all()
+                app.action_copy_selection()
+                mock_sys_copy.assert_called()
+                copied_arg = mock_sys_copy.call_args[0][0]
+                self.assertIn("Copy action message", copied_arg)


### PR DESCRIPTION
… TUI

- Add native OS clipboard integration supporting macOS (pbcopy/pbpaste), Linux (wl-copy/xclip/xsel), and Windows (clip/powershell)
- Override App.copy_to_clipboard to populate both system clipboard and terminal OSC 52
- Handle on_text_selected to auto-copy mouse-selected text to system clipboard
- Add explicit copy key bindings (super+c, ctrl+shift+c, ctrl+insert) and paste binding (super+v)
- Add comprehensive unit and integration tests for clipboard support