### PR TITLE
feat: implement on-demand context compaction slash command (/compact)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Ollama Agent is a powerful command-line tool (CLI and REPL) that allows you to i
 - **Native Ollama Integration**: Connects directly to Ollama's native API (via `langchain-ollama`), no OpenAI compatibility layer needed.
 - **Thinking / Reasoning**: Leverages Ollama's native [thinking capability](https://docs.ollama.com/capabilities/thinking) to expose model reasoning traces. Configurable per model via `--effort`.
 - **Automatic Context Window & Live Monitor**: Resolves effective context window (`num_ctx`) automatically from Ollama metadata and displays real-time token usage and percentage gauge directly in the TUI header.
+- **Context Compression & Compaction**: Built-in automatic summarization and history offloading at 85% of `num_ctx`, plus on-demand context compaction anytime via `/compact`.
 - **Per-session Model Switching**: Change the model mid-conversation and continue from that point with the new model (context preserved). The change is not permanent and only affects the current session.
 - **Tool-Powered**: The agent can execute shell commands via an integrated shell backend, with human-in-the-loop confirmation before running commands and editing files.
 - **MCP Integration**: Extend the main agent with [Model Context Protocol](https://modelcontextprotocol.io/) servers (`mcp_servers.json`) that provide additional tools directly to the agent.
@@ -73,6 +74,7 @@ The REPL provides a persistent chat session. You can use slash commands to manag
 - `/help`: Show available commands.
 - `/model [list | set <model>]`: Manage models (list available models, switch active model).
 - `/session [list | resume <id> | new | export [path] | delete <id>]`: Manage chat sessions (list past sessions, resume previous conversation, export to Markdown, delete).
+- `/compact` (or `/compress`): Compact conversation history into a structured summary to reclaim context window tokens.
 - `/task [list | create <id> | run <id> | delete <id>]`: Manage saved prompt tasks.
 - `/skill [list | show <id> | create <id> | delete <id>]`: Manage agent skills.
 - `/rag [status | list | create <name> | load <name> | unload | add <path> | delete <name>]`: Manage RAG document databases.
@@ -132,6 +134,39 @@ The REPL dynamic header displays the current model, active RAG database, YOLO st
   - 🔵 **Blue/Cyan**: Healthy context usage (<75%).
   - 🟡 **Yellow**: Elevated context warning (>75%).
   - 🔴 **Red**: Critical context limit proximity (>90%).
+
+### Context Compression & Compaction (`/compact`)
+
+Local models running on Ollama often have bounded context windows (e.g. 8k–32k tokens) and can suffer from attention degradation ("lost-in-the-middle") as conversations grow. `ollama-agent` provides built-in context engineering and compaction mechanisms:
+
+```mermaid
+flowchart LR
+    A[Full Conversation History] -->|Auto at 85% num_ctx OR /compact| B[Summarization Engine]
+    B --> C[Structured In-Context Summary]
+    B --> D[History Saved to /conversation_history/thread_id.md]
+    C --> E[Active Context Reclaimed]
+```
+
+1. **Automatic Context Summarization**:
+   - **Threshold**: When conversation tokens cross **85%** of the model's configured context window (`num_ctx`), the summarization engine triggers automatically.
+   - **Retention**: Older turns are compressed into a structured summary (capturing session intent, key decisions, artifacts created, and next steps) while keeping the most recent conversation turns intact.
+   - **History Preservation**: Older messages are never lost; they are appended to `/conversation_history/{thread_id}.md` in the agent backend for durable recovery.
+   - **Tool Argument Truncation**: Large arguments from previous file operations (such as `write_file` or `edit_file`) in older turns are pruned to reclaim context.
+   - **Overflow Resilience**: If a model call encounters a context overflow error, the engine automatically catches it, triggers summarization, and retries the turn seamlessly.
+
+2. **On-Demand Compaction (`/compact` or `/compress`)**:
+   - You can trigger context compaction at any point during a conversation by typing `/compact` (or `/compress`) in the REPL.
+   - Unlike `/new` (which wipes the entire session and starts over), `/compact` preserves the memory of what was done by replacing earlier message turns with a concise summary.
+   - The TUI displays detailed compaction metrics and immediately updates the token gauge in the header:
+
+```text
+❯ /compact
+⚡ Compacting conversation context...
+✓ Context compacted successfully:
+  • Messages summarized: 12
+  • Recent messages preserved: 2
+  • History offloaded to: /conversation_history/a1b2c3d4.md
+```
 
 ### File / Directory Context (@-mentions)
 

--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -13,7 +13,12 @@ from typing import Any, AsyncGenerator, Self, cast
 
 from deepagents import create_deep_agent
 from deepagents.backends import CompositeBackend, FilesystemBackend, LocalShellBackend
-from deepagents.middleware.summarization import create_summarization_tool_middleware
+from deepagents.middleware.summarization import (
+    count_tokens_approximately,
+    create_summarization_middleware,
+    create_summarization_tool_middleware,
+)
+from langchain_core.runnables.config import var_child_runnable_config
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.types import Command
 
@@ -72,6 +77,8 @@ class AgentRuntime:
     auto_approved_tools: set[str] = field(default_factory=set)
     last_context_tokens: int = field(default=0, init=False)
     graph: Any = field(default=None, init=False, repr=False)
+    _backend: Any = field(default=None, init=False, repr=False)
+    _summarization_mw: Any = field(default=None, init=False, repr=False)
     _instructions: str = field(default="", init=False)
     _exit_stack: contextlib.AsyncExitStack = field(
         default_factory=contextlib.AsyncExitStack, init=False, repr=False
@@ -208,6 +215,10 @@ class AgentRuntime:
         if rag_mgr is not None and rag_mgr.current_database is not None:
             tools.append(rag_search)
 
+        summarization_tool_mw = create_summarization_tool_middleware(model, backend)
+        self._backend = backend
+        self._summarization_mw = getattr(summarization_tool_mw, "_summarization", None)
+
         kwargs: dict[str, Any] = {
             "model": model,
             "tools": tools,
@@ -217,7 +228,7 @@ class AgentRuntime:
             "skills": ["/skills/"],
             "checkpointer": await self._sqlite_checkpointer(),
             "middleware": [
-                create_summarization_tool_middleware(model, backend),
+                summarization_tool_mw,
                 stream_tool_events_mw,
             ],
             "name": "ollama-agent",
@@ -309,6 +320,81 @@ class AgentRuntime:
                 self.last_context_tokens = max(1, total_chars // 4)
         if state.interrupts:
             yield {"type": "interrupt", "interrupts": state.interrupts, "config": config}
+
+    async def compact_context(self, thread_id: str = "") -> dict[str, Any]:
+        """Compact conversation history for the specified thread into a summary."""
+        thread = thread_id or self.thread_id
+        if self.graph is None or self._summarization_mw is None or self._backend is None:
+            await self.reload()
+        assert self.graph is not None
+
+        config = {"configurable": {"thread_id": thread}}
+        state = await self.graph.aget_state(config)
+        if not state or not state.values or "messages" not in state.values:
+            return {"success": False, "message": "No messages in session to compact."}
+
+        messages = state.values.get("messages", [])
+        event = state.values.get("_summarization_event")
+        effective = self._summarization_mw._apply_event_to_messages(messages, event)
+
+        if len(effective) < 2:
+            return {
+                "success": False,
+                "message": "Not enough messages in session to compact (at least 2 messages required).",
+            }
+
+        cutoff = self._summarization_mw._determine_cutoff_index(effective)
+        if cutoff <= 0:
+            cutoff = self._summarization_mw._lc_helper._find_safe_cutoff(
+                effective, min(2, len(effective) - 1)
+            )
+            if cutoff <= 0:
+                cutoff = max(1, len(effective) - 1)
+
+        to_summarize, preserved = self._summarization_mw._partition_messages(
+            effective, cutoff
+        )
+        if not to_summarize:
+            return {
+                "success": False,
+                "message": "No messages eligible for summarization.",
+            }
+
+        token = var_child_runnable_config.set(config)
+        try:
+            file_path, summary = await asyncio.gather(
+                self._summarization_mw._aoffload_to_backend(self._backend, to_summarize),
+                self._summarization_mw._acreate_summary(to_summarize),
+            )
+        finally:
+            var_child_runnable_config.reset(token)
+
+        new_messages = self._summarization_mw._build_new_messages_with_path(
+            summary, file_path
+        )
+        state_cutoff_index = self._summarization_mw._compute_state_cutoff(
+            event, cutoff
+        )
+
+        new_event: dict[str, Any] = {
+            "cutoff_index": state_cutoff_index,
+            "summary_message": new_messages[0],
+            "file_path": file_path,
+        }
+
+        await self.graph.aupdate_state(config, {"_summarization_event": new_event})
+
+        self.last_context_tokens = count_tokens_approximately(
+            [new_messages[0], *preserved]
+        )
+
+        return {
+            "success": True,
+            "messages_summarized": len(to_summarize),
+            "messages_preserved": len(preserved),
+            "file_path": file_path,
+            "summary": summary,
+        }
 
 
     async def set_model(self, model_name: str) -> str:

--- a/ollama_agent/interfaces/dispatch.py
+++ b/ollama_agent/interfaces/dispatch.py
@@ -26,7 +26,14 @@ from ..rag import (
 from ..skills import SkillError, SkillsContext, create_skill, delete_skill, list_skills, show_skill
 from ..tasks.commands import CLIContext, TaskError, create_task, delete_task, list_tasks, run_task
 from .model_commands import list_models
-from .session_commands import delete_session, export_session, list_sessions, new_session, resume_session
+from .session_commands import (
+    compact_session,
+    delete_session,
+    export_session,
+    list_sessions,
+    new_session,
+    resume_session,
+)
 
 CLIHandler = Callable[[], object]
 
@@ -134,6 +141,7 @@ def build_repl_handlers(
     current_thread_id: Callable[[], str] = lambda: "",
     handle_session_resume: Callable[[str], Awaitable[None]] | None = None,
     handle_session_export: Callable[[list[str]], Awaitable[None]] | None = None,
+    handle_compact: Callable[[list[str]], Awaitable[None]] | None = None,
 ) -> dict[str, REPLCommand]:
     """Build the REPL command registry for unified slash commands."""
 
@@ -267,6 +275,16 @@ def build_repl_handlers(
             "Session Management",
             None,
             handle_new,
+        ),
+        "/compact": REPLCommand(
+            "Compact conversation history into a summary",
+            "Session Management",
+            None,
+            (
+                handle_compact
+                if handle_compact is not None
+                else (lambda _: None)
+            ),
         ),
         "/session": REPLCommand(
             "Manage chat sessions (list, resume, new, export, delete)",

--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -16,6 +16,7 @@ from textual.worker import Worker
 from textual.containers import Container, Horizontal, ScrollableContainer
 from textual.widgets import Static, OptionList, TextArea
 from textual.widgets.option_list import Option
+from deepagents.middleware.summarization import count_tokens_approximately
 from langgraph.types import Command
 
 from .clipboard import copy_to_system_clipboard, get_system_clipboard
@@ -42,6 +43,7 @@ from ..tasks.commands import CLIContext, TaskError, create_task
 from .dispatch import REPLCommand, build_repl_handlers, render_repl_help, safe_call
 from .model_commands import set_model
 from .session_commands import (
+    compact_session,
     delete_session,
     export_session,
     get_available_sessions,
@@ -59,6 +61,7 @@ _AT_MENTION_RE = re.compile(
 _ROOT_COMMANDS: list[tuple[str, str]] = [
     ("/model", "Manage models (list, set)"),
     ("/session", "Manage chat sessions (list, resume, new, export, delete)"),
+    ("/compact", "Compact conversation history into a summary"),
     ("/task", "Manage saved tasks (list, create, run, delete)"),
     ("/skill", "Manage skills (list, show, create, delete)"),
     ("/rag", "Manage RAG databases (status, list, create, delete, load, unload, add)"),
@@ -516,6 +519,25 @@ class OllamaAgentApp(App):
             await scroll.remove_children()
             return
 
+        if cmd in ("/compact", "/compress"):
+            scroll.mount(SystemMessage("[dim]⚡ Compacting conversation context...[/dim]"))
+            self._deferred_scroll()
+            res = await self.repl.runtime.compact_context()
+            if res["success"]:
+                msg_text = (
+                    f"[bold #38bdf8]✓ Context compacted successfully:[/bold #38bdf8]\n"
+                    f"  • [dim]Messages summarized:[/dim] {res['messages_summarized']}\n"
+                    f"  • [dim]Recent messages preserved:[/dim] {res['messages_preserved']}"
+                )
+                if res.get("file_path"):
+                    msg_text += f"\n  • [dim]History offloaded to:[/dim] [cyan]{res['file_path']}[/cyan]"
+                scroll.mount(SystemMessage(msg_text))
+                self.query_one(AgentHeader).update_header()
+            else:
+                scroll.mount(SystemMessage(f"[bold #f87171]✕ Compaction skipped:[/bold #f87171] {res.get('message', 'Failed to compact.')}"))
+            self._deferred_scroll()
+            return
+
         if cmd == "/session" and args and args[0] in ("resume", "switch"):
             if len(args) < 2:
                 scroll.mount(SystemMessage("[bold #f87171]✕ Usage:[/bold #f87171] /session resume <session_id>"))
@@ -529,7 +551,19 @@ class OllamaAgentApp(App):
                     config = {"configurable": {"thread_id": resolved}}
                     state = await self.repl.runtime.graph.aget_state(config)
                     if state and state.values and "messages" in state.values:
-                        for msg in state.values["messages"]:
+                        messages = state.values["messages"]
+                        event = state.values.get("_summarization_event")
+                        effective = (
+                            self.repl.runtime._summarization_mw._apply_event_to_messages(
+                                messages, event
+                            )
+                            if self.repl.runtime._summarization_mw
+                            else messages
+                        )
+                        self.repl.runtime.last_context_tokens = (
+                            count_tokens_approximately(effective)
+                        )
+                        for msg in messages:
                             role = getattr(msg, "type", None) or getattr(msg, "role", "unknown")
                             content = extract_text(getattr(msg, "content", ""))
                             if not content:
@@ -765,8 +799,13 @@ class OllamaREPL:
                 current_thread_id=lambda: self.runtime.thread_id,
                 handle_session_resume=self._handle_session_resume,
                 handle_session_export=self._handle_session_export,
+                handle_compact=self._handle_compact,
             )
         return self._commands
+
+    async def _handle_compact(self, args: list[str]) -> None:
+        target_id = args[0] if args else self.runtime.thread_id
+        await compact_session(self.console, self.runtime, target_id)
 
     async def _handle_session_resume(self, session_id: str) -> None:
         resolved = resume_session(self.console, session_id)

--- a/ollama_agent/interfaces/session_commands.py
+++ b/ollama_agent/interfaces/session_commands.py
@@ -203,3 +203,21 @@ async def export_session(
     except OSError as exc:
         console.print(f"[red]Failed to export session: {exc}[/red]")
         return None
+
+
+async def compact_session(
+    console: Console,
+    runtime: AgentRuntime,
+    target_id: str = "",
+) -> dict[str, Any]:
+    """Compact conversation context for a session into a structured summary."""
+    res = await runtime.compact_context(target_id)
+    if res["success"]:
+        console.print("[green]✓ Context compacted successfully:[/green]")
+        console.print(f"  [dim]• Messages summarized:[/dim] {res['messages_summarized']}")
+        console.print(f"  [dim]• Recent messages preserved:[/dim] {res['messages_preserved']}")
+        if res.get("file_path"):
+            console.print(f"  [dim]• History offloaded to:[/dim] [cyan]{res['file_path']}[/cyan]")
+    else:
+        console.print(f"[yellow]{res.get('message', 'Compaction failed.')}[/yellow]")
+    return res

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -6,6 +6,7 @@ from contextlib import AsyncExitStack
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.types import Command
 
 from ollama_agent.agent.agent import AgentRuntime, _process_message_chunk
@@ -306,4 +307,67 @@ class TestAgentRuntimeComponents(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(len(events), 1)
             self.assertEqual(events[0]["type"], "error")
             self.assertIn("Invalid file mention", events[0]["content"])
+
+    async def test_compact_context_empty_or_too_few(self) -> None:
+        settings = Settings()
+        runtime = AgentRuntime(settings=settings)
+        mock_graph = MagicMock()
+        mock_state_empty = MagicMock(values={})
+        mock_graph.aget_state = AsyncMock(return_value=mock_state_empty)
+        runtime.graph = mock_graph
+        runtime._summarization_mw = MagicMock()
+        runtime._backend = MagicMock()
+
+        # Empty messages
+        res = await runtime.compact_context("thread-1")
+        self.assertFalse(res["success"])
+        self.assertIn("No messages", res["message"])
+
+        # 1 message (< 2)
+        mock_state_single = MagicMock(values={"messages": [MagicMock(content="hello")]})
+        mock_graph.aget_state = AsyncMock(return_value=mock_state_single)
+        runtime._summarization_mw._apply_event_to_messages.return_value = [MagicMock(content="hello")]
+        res2 = await runtime.compact_context("thread-1")
+        self.assertFalse(res2["success"])
+        self.assertIn("Not enough messages", res2["message"])
+
+    async def test_compact_context_success(self) -> None:
+        settings = Settings()
+        runtime = AgentRuntime(settings=settings)
+        mock_graph = MagicMock()
+        msg1 = HumanMessage(content="First prompt")
+        msg2 = AIMessage(content="First answer")
+        msg3 = HumanMessage(content="Second prompt")
+        msg4 = AIMessage(content="Second answer")
+
+        mock_state = MagicMock(values={"messages": [msg1, msg2, msg3, msg4], "_summarization_event": None})
+        mock_graph.aget_state = AsyncMock(return_value=mock_state)
+        mock_graph.aupdate_state = AsyncMock()
+        runtime.graph = mock_graph
+
+        mock_mw = MagicMock()
+        mock_mw._apply_event_to_messages.return_value = [msg1, msg2, msg3, msg4]
+        mock_mw._determine_cutoff_index.return_value = 2
+        mock_mw._partition_messages.return_value = ([msg1, msg2], [msg3, msg4])
+        mock_mw._aoffload_to_backend = AsyncMock(return_value="/conversation_history/thread-1.md")
+        mock_mw._acreate_summary = AsyncMock(return_value="Summary of first turn")
+        summary_human_msg = HumanMessage(content="Condensed summary")
+        mock_mw._build_new_messages_with_path.return_value = [summary_human_msg]
+        mock_mw._compute_state_cutoff.return_value = 2
+
+        runtime._summarization_mw = mock_mw
+        runtime._backend = MagicMock()
+
+        res = await runtime.compact_context("thread-1")
+        self.assertTrue(res["success"])
+        self.assertEqual(res["messages_summarized"], 2)
+        self.assertEqual(res["messages_preserved"], 2)
+        self.assertEqual(res["file_path"], "/conversation_history/thread-1.md")
+        self.assertEqual(res["summary"], "Summary of first turn")
+
+        mock_graph.aupdate_state.assert_awaited_once()
+        update_call = mock_graph.aupdate_state.call_args
+        self.assertEqual(update_call[0][0], {"configurable": {"thread_id": "thread-1"}})
+        self.assertEqual(update_call[0][1]["_summarization_event"]["cutoff_index"], 2)
+        self.assertGreater(runtime.last_context_tokens, 0)
 

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -101,6 +101,7 @@ class TestDispatchAndCLI(unittest.TestCase):
         self.assertIn("/model", handlers)
         self.assertIn("/yolo", handlers)
         self.assertIn("/new", handlers)
+        self.assertIn("/compact", handlers)
         self.assertIn("/task", handlers)
         self.assertIn("/skill", handlers)
         self.assertIn("/rag", handlers)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 from rich.console import Console
 
 from ollama_agent.interfaces.session_commands import (
+    compact_session,
     delete_session,
     export_session,
     get_available_sessions,
@@ -129,6 +130,42 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         self.assertIn("How do I create a class?", content)
         self.assertIn("Assistant", content)
         self.assertIn("Use `class MyClass:` syntax.", content)
+
+    async def test_compact_session_success(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime_mock = MagicMock()
+        runtime_mock.compact_context = AsyncMock(
+            return_value={
+                "success": True,
+                "messages_summarized": 8,
+                "messages_preserved": 2,
+                "file_path": "/conversation_history/session-1234.md",
+                "summary": "Summary of conversation",
+            }
+        )
+
+        res = await compact_session(console, runtime_mock, "session-1234")
+        self.assertTrue(res["success"])
+        out = console.export_text()
+        self.assertIn("Context compacted successfully", out)
+        self.assertIn("Messages summarized: 8", out)
+        self.assertIn("Recent messages preserved: 2", out)
+        self.assertIn("/conversation_history/session-1234.md", out)
+
+    async def test_compact_session_failed(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime_mock = MagicMock()
+        runtime_mock.compact_context = AsyncMock(
+            return_value={
+                "success": False,
+                "message": "Not enough messages in session to compact (at least 2 messages required).",
+            }
+        )
+
+        res = await compact_session(console, runtime_mock, "session-1234")
+        self.assertFalse(res["success"])
+        out = console.export_text()
+        self.assertIn("Not enough messages in session to compact", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add AgentRuntime.compact_context with LangGraph checkpoint state integration
- Register /compact (and /compress alias) in REPL and dispatch interfaces
- Recalculate context token usage accurately upon compaction and session resume
- Document context compression and /compact in README.md
- Add comprehensive unit tests for compaction and session commands