### PR TITLE
feat: change input box border color to red in YOLO mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ When you want autonomous execution without confirmation pauses:
 When YOLO mode is active:
 1. Tool approval prompts are bypassed automatically.
 2. The header displays `YOLO: ON` with a red highlight badge.
-3. The prompt chevron changes color to **red** (`❯ `) for clear visual status.
+3. The prompt chevron (`❯ `) and input box border change color to **red** for clear visual status.
 
 ---
 

--- a/docs/cli_repl.md
+++ b/docs/cli_repl.md
@@ -271,7 +271,7 @@ When you want autonomous execution without confirmation pauses:
 When YOLO mode is active:
 1. Tool approval prompts are bypassed automatically.
 2. The header displays `YOLO: ON` with a highlighted badge.
-3. The prompt chevron changes color to **red** (`❯ `) for clear visual status.
+3. The prompt chevron (`❯ `) and input box border change color to **red** for clear visual status.
 
 ---
 

--- a/ollama_agent/interfaces/repl.css
+++ b/ollama_agent/interfaces/repl.css
@@ -65,6 +65,10 @@ AgentHeader {
     border: round #38bdf8;
 }
 
+#input-container.yolo-mode:focus-within {
+    border: round #f87171;
+}
+
 #input-bar {
     height: auto;
     min-height: 2;

--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -240,6 +240,8 @@ class OllamaAgentApp(App):
 
     def update_yolo_ui(self) -> None:
         prompt_char = self.query_one("#prompt-char")
+        input_container = self.query_one("#input-container")
+        input_container.set_class(self.repl.runtime.yolo_mode, "yolo-mode")
         if self.repl.runtime.yolo_mode:
             prompt_char.styles.color = "#f87171"  # Red / Coral
         else:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -338,11 +338,14 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
             repl_mock.runtime.yolo_mode = True
             app.update_yolo_ui()
             prompt_char = app.query_one("#prompt-char")
+            input_container = app.query_one("#input-container")
             self.assertEqual(prompt_char.styles.color.hex, "#F87171")
+            self.assertTrue(input_container.has_class("yolo-mode"))
 
             repl_mock.runtime.yolo_mode = False
             app.update_yolo_ui()
             self.assertEqual(prompt_char.styles.color.hex, "#38BDF8")
+            self.assertFalse(input_container.has_class("yolo-mode"))
 
     async def test_autocomplete_trigger(self) -> None:
         repl_mock = MagicMock()


### PR DESCRIPTION
## Summary
- Changes the input box border color to red (`#f87171`) when YOLO mode is active in the REPL TUI.
- Updates `repl.css` with `#input-container.yolo-mode:focus-within` rule.
- Updates `repl.py` `update_yolo_ui` to dynamically toggle the `yolo-mode` class on `#input-container`.
- Adds unit tests in `tests/test_tui.py`.
- Updates `README.md` and `docs/cli_repl.md`.