### PR TITLE
feat(memory): add episodic memory search engine, agent tool, and CLI/REPL commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,37 +12,46 @@
 ## Table of Contents
 
 - [Features](#features)
-- [Prerequisites](#prerequisites)
-- [Installation](#installation)
+- [Prerequisites & Installation](#prerequisites--installation)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Interactive REPL Interface](#interactive-repl-interface)
-  - [Slash Commands](#slash-commands)
   - [Multiline Input & Navigation](#multiline-input--navigation)
+  - [Slash Commands](#slash-commands)
   - [Live Context Usage & Token Gauge](#live-context-usage--token-gauge)
   - [Human-in-the-Loop (HITL) & YOLO Mode](#human-in-the-loop-hitl--yolo-mode)
-  - [Context Compression & Compaction (`/compact`)](#context-compression--compaction-compact)
   - [File & Directory Context (`@-mentions`)](#file--directory-context--mentions)
-- [CLI Reference & Options](#cli-reference--options)
-  - [Non-Interactive Mode](#non-interactive-mode)
+  - [Context Compression & Compaction (`/compact`)](#context-compression--compaction-compact)
+- [CLI Reference & Automation](#cli-reference--automation)
   - [Global Options & Flags](#global-options--flags)
+  - [Non-Interactive Mode](#non-interactive-mode)
+  - [CLI Subcommands Summary](#cli-subcommands-summary)
   - [Thinking / Reasoning Effort Mapping](#thinking--reasoning-effort-mapping)
-- [Session Management](#session-management)
-- [Task Management](#task-management)
-- [Agent Skills](#agent-skills)
-- [RAG (Retrieval Augmented Generation)](#rag-retrieval-augmented-generation)
-- [Persistent Memory & Project Guidelines](#persistent-memory--project-guidelines)
-- [Configuration & Settings](#configuration--settings)
-  - [Configuration File (`settings.yaml`)](#configuration-file-settingsyaml)
-  - [Context Window Resolution](#context-window-resolution)
-  - [Configuration Reset (`--config-reset`)](#configuration-reset---config-reset)
-  - [LangSmith Tracing](#langsmith-tracing)
-  - [Agent System Prompts](#agent-system-prompts)
+- [Memory, Sessions & Guidelines](#memory-sessions--guidelines)
+  - [1. Repository Project Guidelines (`AGENTS.md`)](#1-repository-project-guidelines-agentsmd)
+  - [2. Global Agent Guidelines (`~/.ollama-agent/AGENTS.md`)](#2-global-agent-guidelines-ollama-agentagentsmd)
+  - [3. Cross-Session Memory (`~/.ollama-agent/MEMORY.md`)](#3-cross-session-memory-ollama-agentmemorymd)
+  - [4. Session History & Resumption (`history.db`)](#4-session-history--resumption-historydb)
+  - [5. Episodic Memory & Conversation Recall](#5-episodic-memory--conversation-recall)
+- [Productivity & Knowledge Tools](#productivity--knowledge-tools)
+  - [Saved Tasks](#saved-tasks)
+  - [Agent Skills Standard](#agent-skills-standard)
+  - [Local RAG (Retrieval Augmented Generation)](#local-rag-retrieval-augmented-generation)
 - [Extensibility: MCP & Custom Subagents](#extensibility-mcp--custom-subagents)
   - [MCP Servers (Main Agent)](#mcp-servers-main-agent)
   - [Custom Subagents](#custom-subagents)
+- [Configuration & Customization](#configuration--customization)
+  - [Configuration File (`settings.yaml`)](#configuration-file-settingsyaml)
+  - [Settings Reference](#settings-reference)
+  - [Context Window Resolution](#context-window-resolution)
+  - [Agent System Prompts](#agent-system-prompts)
+  - [Configuration Reset (`--config-reset`)](#configuration-reset---config-reset)
+  - [LangSmith Tracing](#langsmith-tracing)
 - [Developer Guide](#developer-guide)
   - [Project Setup](#project-setup)
   - [Project Structure](#project-structure)
+- [License](#license)
 
 ---
 
@@ -51,7 +60,7 @@
 - 🖥️ **Interactive Terminal REPL**: Modern Textual-powered TUI featuring rich Markdown rendering, multiline editing (`\ + Enter`), slash command autocompletion, and live session status.
 - ⚡ **Non-Interactive CLI**: Execute single prompts directly from your shell for automation, scripting, and quick queries.
 - 🦙 **Native Ollama Integration**: Direct communication via Ollama's native API (`langchain-ollama`) — no OpenAI compatibility proxy required.
-- 🧠 **Native Thinking / Reasoning Traces**: Harnesses Ollama's native reasoning support. Configurable effort levels (`low`, `medium`, `high`, `disabled`, `hide`, `enabled`) per model and session.
+- 🧠 **Native Thinking / Reasoning Traces**: Harnesses Ollama's native reasoning support. Configurable effort levels (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`) per model and session.
 - 📊 **Automatic Context Resolution & Live Monitor**: Dynamically inspects model context limits (`num_ctx`) and displays real-time token consumption with color-coded gauge alerts in the TUI header.
 - 🗜️ **Context Compression & Compaction**: Automatic background summarization and history offloading at 85% context capacity, plus on-demand context compaction anytime via `/compact` or `/compress`.
 - 🔄 **Per-Session Model Switching**: Change models mid-conversation (`/model set <name>`) while preserving the conversation context for the active session.
@@ -67,20 +76,21 @@
 
 ---
 
-## Prerequisites
+## Prerequisites & Installation
+
+### Prerequisites
 
 Before running Ollama Agent, ensure the following dependencies are available on your system:
 
-1. **Ollama**: Installed and running locally (or reachable at your configured host).
-2. **Tool-Calling Model**: A local model with tool/function-calling capabilities (e.g. `gemma4:26b`, `qwen2.5:14b`, `llama3.1:8b`). If the selected model lacks tool support, the agent will report an error and exit.
-3. **Embeddings Model (for RAG)**: If using RAG features, download the default embedding model in Ollama:
+1. **Python 3.11+**: Ensure Python 3.11 or newer is installed.
+2. **Ollama**: Installed and running locally (or reachable at your configured host).
+3. **Tool-Calling Model**: A local model with tool/function-calling capabilities (e.g. `gemma4:26b`, `qwen2.5:14b`, `llama3.1:8b`). If the selected model lacks tool support, the agent will report an error and exit.
+4. **Embeddings Model (for RAG)**: If using RAG features, download the default embedding model in Ollama:
    ```bash
    ollama pull nomic-embed-text:latest
    ```
 
----
-
-## Installation
+### Installation
 
 For end-users, the recommended installation method is using **`pipx`**, which installs the application in an isolated environment and adds the `ollama-agent` executable to your system PATH:
 
@@ -132,6 +142,20 @@ The interactive REPL is a full-featured terminal UI built on Textual and Rich, p
 ❯ /help
 ```
 
+---
+
+### Multiline Input & Navigation
+
+The REPL prompt input supports convenient multiline editing, history recall, and tab completion:
+
+- **Insert Newline**: End the current line with a backslash `\` and press `Enter` (`\ + Enter`). The trailing backslash is automatically stripped, inserting a clean newline. The input box dynamically expands up to 8 lines.
+- **Submit Prompt**: Press `Enter` without a trailing backslash to send your message.
+- **Cursor Navigation**: Use `↑` and `↓` arrow keys to move freely across lines in multiline prompts.
+- **Command History**: Pressing `↑` at the top-left `(row 0, col 0)` navigates to previous prompts; pressing `↓` at the end of the text navigates forward.
+- **Tab Autocompletion**: Press `Tab` to autocomplete slash commands, subcommands, entity IDs (sessions, tasks, skills, RAG databases), and `@-mention` file paths.
+
+---
+
 ### Slash Commands
 
 The REPL provides built-in slash commands for managing models, sessions, tasks, skills, and memory. Commands and entities support **3-level tab autocompletion**:
@@ -149,18 +173,6 @@ The REPL provides built-in slash commands for managing models, sessions, tasks, 
 | `/new` | `/new` | Start a clean new session with fresh context (alias for `/session new`). |
 | `/clear` | `/clear` | Clear rendered message cards from the active chat scroll viewport. |
 | `/exit` | `/exit` (alias: `/quit`) | Exit the application cleanly. |
-
----
-
-### Multiline Input & Navigation
-
-The REPL prompt input supports convenient multiline editing and history recall:
-
-- **Insert Newline**: End the current line with a backslash `\` and press `Enter` (`\ + Enter`). The trailing backslash is automatically stripped, inserting a clean newline. The input box dynamically expands up to 8 lines.
-- **Submit Prompt**: Press `Enter` without a trailing backslash to send your message.
-- **Cursor Navigation**: Use `↑` and `↓` arrow keys to move freely across lines in multiline prompts.
-- **Command History**: Pressing `↑` at the top-left `(row 0, col 0)` navigates to previous prompts; pressing `↓` at the end of the text navigates forward.
-- **Tab Autocompletion**: Press `Tab` to autocomplete slash commands, subcommands, entity IDs (sessions, tasks, skills, RAG databases), and `@-mention` file paths.
 
 ---
 
@@ -211,6 +223,36 @@ When YOLO mode is active:
 
 ---
 
+### File & Directory Context (`@-mentions`)
+
+Reference files or entire folder trees directly inside your prompts using `@` syntax. The agent resolves the paths and injects the contents into the model's context.
+
+- **Single Files**: `@filename.txt`, `@src/main.py`
+- **Quoted Paths (with spaces)**: `@"my notes/todo.txt"` or `@'my notes/todo.txt'`
+- **Directory Traversal**: `@src` or `@.` (recursively reads all supported text files within the directory).
+- **Interactive Autocompletion**: Type `@` and press `Tab` in the REPL to interactively search and insert file paths.
+
+#### Supported Content Types
+- **Text Files**: Read as UTF-8 and attached as structured `<context_file path="...">...</context_file>` blocks.
+- **Multimodal Attachments**: Images (`.png`, `.jpg`, `.webp`, `.gif`, `.svg`), audio (`.mp3`, `.wav`, `.ogg`, `.flac`), video (`.mp4`, `.mov`, `.webm`), and documents (`.pdf`, `.pptx`) are base64-encoded and attached as native multimodal inputs.
+- **Binary Safety**: Non-multimodal binaries (e.g. `.zip`, `.exe`, `.pyc`) are skipped during directory traversal.
+
+#### Safety Limits & Configuration
+Configurable under the `mentions` section in `~/.ollama-agent/settings.yaml`:
+
+```yaml
+mentions:
+  max_file_size: 1048576      # Max single file size (default: 1 MB)
+  max_files: 100               # Max files loaded in directory traversal (default: 100)
+  max_total_size: 10485760     # Max total attached context size (default: 10 MB)
+  max_completions: 200         # Max autocompletion candidates (default: 200)
+```
+
+#### Decorator & Syntax Safety
+Common programming decorators (e.g. `@staticmethod`, `@property`, `@decorator`) that do not exist as files on disk are recognized and treated as literal text. If a missing path contains directory separators (e.g. `@src/missing.py`) or a file extension (e.g. `@app.py`), the agent immediately halts and reports a clear `File or directory not found` error.
+
+---
+
 ### Context Compression & Compaction (`/compact`)
 
 To prevent conversation degradation and context overflow errors, Ollama Agent features both automatic context compression and on-demand compaction.
@@ -244,45 +286,7 @@ flowchart LR
 
 ---
 
-### File & Directory Context (`@-mentions`)
-
-Reference files or entire folder trees directly inside your prompts using `@` syntax. The agent resolves the paths and injects the contents into the model's context.
-
-- **Single Files**: `@filename.txt`, `@src/main.py`
-- **Quoted Paths (with spaces)**: `@"my notes/todo.txt"` or `@'my notes/todo.txt'`
-- **Directory Traversal**: `@src` or `@.` (recursively reads all supported text files within the directory).
-- **Interactive Autocompletion**: Type `@` and press `Tab` in the REPL to interactively search and insert file paths.
-
-#### Supported Content Types
-- **Text Files**: Read as UTF-8 and attached as structured `<context_file path="...">...</context_file>` blocks.
-- **Multimodal Attachments**: Images (`.png`, `.jpg`, `.webp`, `.gif`, `.svg`), audio (`.mp3`, `.wav`, `.ogg`, `.flac`), video (`.mp4`, `.mov`, `.webm`), and documents (`.pdf`, `.pptx`) are base64-encoded and attached as native multimodal inputs.
-- **Binary Safety**: Non-multimodal binaries (e.g. `.zip`, `.exe`, `.pyc`) are skipped during directory traversal.
-
-#### Safety Limits & Configuration
-Configurable under the `mentions` section in `~/.ollama-agent/settings.yaml`:
-
-```yaml
-mentions:
-  max_file_size: 1048576      # Max single file size (default: 1 MB)
-  max_files: 100               # Max files loaded in directory traversal (default: 100)
-  max_total_size: 10485760     # Max total attached context size (default: 10 MB)
-  max_completions: 200         # Max autocompletion candidates (default: 200)
-```
-
-#### Decorator & Syntax Safety
-Common programming decorators (e.g. `@staticmethod`, `@property`, `@decorator`) that do not exist as files on disk are recognized and treated as literal text. If a missing path contains directory separators (e.g. `@src/missing.py`) or a file extension (e.g. `@app.py`), the agent immediately halts and reports a clear `File or directory not found` error.
-
----
-
-## CLI Reference & Options
-
-### Non-Interactive Mode
-
-Execute single prompts directly from your shell without opening the TUI:
-
-```bash
-ollama-agent -p "Extract all email addresses from logs/app.log."
-```
+## CLI Reference & Automation
 
 ### Global Options & Flags
 
@@ -290,7 +294,7 @@ ollama-agent -p "Extract all email addresses from logs/app.log."
 | :--- | :--- | :--- | :--- | :--- |
 | `--model` | `-m` | `str` | `gemma4:26b` | Specify the Ollama model for this session. |
 | `--prompt` | `-p` | `str` | `None` | Run in non-interactive mode with the provided prompt. |
-| `--effort` | `-e` | `str` | `medium` | Set reasoning effort level (`low`, `medium`, `high`, `disabled`, `hide`, `enabled`). |
+| `--effort` | `-e` | `str` | `medium` | Set reasoning effort level (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`). |
 | `--builtin-tool-timeout` | `-t` | `int` | `30` | Timeout in seconds for tool executions (including shell commands). |
 | `--yolo` | `-y` | `flag` | `False` | Enable YOLO mode (bypasses all tool approval prompts). |
 | `--rag` | — | `str` | `None` | Preload a RAG database collection at startup. |
@@ -300,33 +304,91 @@ ollama-agent -p "Extract all email addresses from logs/app.log."
 
 ---
 
+### Non-Interactive Mode
+
+Execute single prompts directly from your shell without opening the TUI:
+
+```bash
+ollama-agent -p "Extract all email addresses from logs/app.log."
+```
+
+Combine with specific models, effort levels, and YOLO execution for scripting:
+
+```bash
+ollama-agent -m "qwen2.5:14b" -e "high" -y -p "Generate a pytest test suite for src/parser.py."
+```
+
+---
+
+### CLI Subcommands Summary
+
+In addition to top-level flags, Ollama Agent provides dedicated CLI subcommands for scriptable management:
+
+| Domain | Subcommand | Example Usage | Description |
+| :--- | :--- | :--- | :--- |
+| **Sessions** | `session-list` | `ollama-agent session-list` | List all saved chat sessions. |
+| | `session-search` | `ollama-agent session-search "sqlite fix"` | Search past sessions by keyword. |
+| | `session-export` | `ollama-agent session-export <id> -o export.md` | Export a session to Markdown. |
+| | `session-delete` | `ollama-agent session-delete <id>` | Delete a session from SQLite history. |
+| **Tasks** | `task-list` | `ollama-agent task-list` | List all saved YAML tasks. |
+| | `task-create` | `ollama-agent task-create review --title "..." --task-prompt "..."` | Create a reusable task. |
+| | `task-run` | `ollama-agent task-run review -y` | Execute a task from CLI. |
+| | `task-delete` | `ollama-agent task-delete review` | Delete a saved task. |
+| **Skills** | `skill-list` | `ollama-agent skill-list` | List all discovered agent skills. |
+| | `skill-show` | `ollama-agent skill-show <id>` | Display skill metadata & instructions. |
+| | `skill-create` | `ollama-agent skill-create <id> --name "..." --description "..." --instructions "..."` | Create a new skill directory & `SKILL.md`. |
+| | `skill-delete` | `ollama-agent skill-delete <id>` | Delete a skill directory. |
+| **RAG** | `rag-list` | `ollama-agent rag-list` | List all local RAG vector databases. |
+| | `rag-create` | `ollama-agent rag-create docs-kb` | Create a new Qdrant vector database. |
+| | `rag-add` | `ollama-agent rag-add docs-kb ./docs --dir` | Index a file or directory into a RAG collection. |
+| | `rag-delete` | `ollama-agent rag-delete docs-kb` | Delete a RAG database. |
+
+---
+
 ### Thinking / Reasoning Effort Mapping
 
 The `--effort` flag (and `model.reasoning_effort` in `settings.yaml`) controls model reasoning traces via Ollama's native thinking capabilities:
 
 | Model Family | `--effort` Value | Ollama API Parameter | Behavior |
 | :--- | :--- | :--- | :--- |
-| **Qwen 3.8** | `xhigh` / `medium` / `low` | `"xhigh"` / `"medium"` / `"low"` | Sets reasoning depth and controls cost (`xhigh` [default]: complex tasks demanding thorough analysis; `medium`: balancing accuracy and speed; `low`: efficient reasoning optimizing for speed and cost). |
-| **Qwen 3.8** | `high` / `enabled` | `"xhigh"` | Enables reasoning with default `xhigh` level. |
-| **Qwen 3.8** | `hide` | `"xhigh"` | Generates reasoning trace at default level but collapses/hides it from the UI. |
-| **Qwen 3.8** | `disabled` | `false` | Disables reasoning trace generation at the model level. |
-| **GPT-OSS** | `low` / `medium` / `high` | `"low"` / `"medium"` / `"high"` | Sets thinking trace depth. GPT-OSS accepts string effort levels. |
-| **GPT-OSS** | `disabled` / `hide` | *(omitted)* | GPT-OSS cannot disable thinking; emits warning, uses default effort, and hides reasoning trace in UI. |
+| **GPT-OSS** | `low` / `medium` / `high` / `xhigh` | `"low"` / `"medium"` / `"high"` / `"xhigh"` | Sets thinking trace depth. GPT-OSS accepts string effort levels. |
 | **GPT-OSS** | `enabled` | `"medium"` | Enables thinking with default `medium` level. |
-| **Other Reasoning Models**<br>*(Qwen 3, DeepSeek R1, DeepSeek-v3.1)* | `low` / `medium` / `high` / `xhigh` / `enabled` | `true` | Enables native reasoning generation. |
-| **Other Reasoning Models** | `hide` | `true` | Generates reasoning trace but collapses/hides it from the UI. |
-| **Other Reasoning Models** | `disabled` | `false` | Disables reasoning trace generation at the model level. |
+| **GPT-OSS** | `hide` | *(omitted)* | Uses model default effort and hides reasoning trace in UI. |
+| **GPT-OSS** | `disabled` | *(omitted)* | GPT-OSS cannot disable thinking; emits warning, uses default effort, and hides reasoning trace in UI. |
+| **Reasoning Models**<br>*(Qwen 2.5/3, DeepSeek R1, DeepSeek-v3.1)* | `low` / `medium` / `high` / `xhigh` / `enabled` | `true` | Enables native reasoning generation. |
+| **Reasoning Models** | `hide` | `true` | Generates reasoning trace but collapses/hides it from the UI. |
+| **Reasoning Models** | `disabled` | `false` | Disables reasoning trace generation at the model level. |
 | **Non-Thinking Models** | *(any)* | *(omitted)* | Setting is ignored gracefully. |
 
 ---
 
-## Session Management
+## Memory, Sessions & Guidelines
 
+Ollama Agent combines repository-specific guidelines, global user preferences, persistent multi-turn session checkpoints, and episodic memory search into a unified memory context.
+
+```mermaid
+flowchart TD
+    A[Agent Startup] --> B[1. Load Repository Guidelines\nAGENTS.md / agents.md up to .git root]
+    A --> C[2. Load Global User Guidelines\n~/.ollama-agent/AGENTS.md]
+    A --> D[3. Mount Cross-Session Memory\n~/.ollama-agent/MEMORY.md]
+    B & C & D --> E[Unified Agent Memory Context]
+```
+
+### 1. Repository Project Guidelines (`AGENTS.md`)
+The agent searches the current working directory and ascends parent directories up to the repository root (`.git`) for `AGENTS.md` (or `agents.md`, `.agents.md`). Discovered instructions are mounted directly into agent memory.
+
+### 2. Global Agent Guidelines (`~/.ollama-agent/AGENTS.md`)
+Initialized automatically by the runtime to maintain user-wide coding standards across all repositories and directories.
+
+### 3. Cross-Session Memory (`~/.ollama-agent/MEMORY.md`)
+Maintained by the agent across sessions to record user preferences, persistent architectural decisions, and project notes. When you instruct the agent to remember something (e.g. *"remember that we always use pytest"*), it updates this file.
+
+### 4. Session History & Resumption (`history.db`)
 All conversations are saved to a local SQLite database at `~/.ollama-agent/history.db` using LangGraph checkpoints, enabling full session resumption and markdown export.
 
 | Action | REPL Command | CLI Command | Description |
 | :--- | :--- | :--- | :--- |
-| **List Sessions** | `/session list` | `ollama-agent session-list` | Display saved sessions with thread IDs, message counts, and active status. |
+| **List Sessions** | `/session list` | `ollama-agent session-list` | Display saved sessions with thread IDs, step counts, and active status. |
 | **Search Sessions** | `/session search <query>` | `ollama-agent session-search <query>` | Search across past chat sessions and conversations by keyword. |
 | **Resume Session** | `/session resume <id>` | — | Resume a past conversation by exact ID or prefix, restoring message history into the viewport. |
 | **New Session** | `/session new` (or `/new`) | — | Initialize a fresh conversation session with a new thread ID. |
@@ -336,13 +398,20 @@ All conversations are saved to a local SQLite database at `~/.ollama-agent/histo
 > [!TIP]
 > In the REPL, typing `/session resume ` or `/session delete ` dynamically lists and autocompletes available session IDs.
 
+### 5. Episodic Memory & Conversation Recall
+Allows the AI agent to search and recall past conversation sessions, past troubleshooting steps, and previous architectural decisions stored in `~/.ollama-agent/history.db`:
+- **Autonomous Agent Tool**: The `search_past_conversations` tool is available to the agent so it can query prior sessions on demand when asked about past context (e.g., *"how did we resolve the database migration issue yesterday?"*).
+- **User Discovery**: Users can also search past sessions manually via `/session search <query>` in the REPL or `ollama-agent session-search <query>` in the CLI.
+
 ---
 
-## Task Management
+## Productivity & Knowledge Tools
+
+### Saved Tasks
 
 Tasks are reusable prompt templates stored as YAML files in `~/.ollama-agent/tasks/`.
 
-### 1. CLI Task Commands
+#### 1. CLI Task Commands
 
 ```bash
 # Create a task
@@ -362,13 +431,13 @@ ollama-agent task-run code-review -y
 ollama-agent task-delete code-review
 ```
 
-### 2. REPL Task Management & Modal Dialogs
+#### 2. REPL Task Management & Modal Dialogs
 
 - **Create via Modal**: Type `/task create my-task` in the REPL to open an interactive modal dialog with fields for Task ID, Title, Model, Reasoning Effort, and a multiline prompt editor.
 - **Run in REPL**: Type `/task run code-review` (or `/task run code-review -y`) to execute the task streaming directly in the active chat.
 - **List / Delete**: Use `/task list` and `/task delete <id>`.
 
-### 3. Manual Task Definition
+#### 3. Manual Task Definition
 
 Create `<task_id>.yaml` inside `~/.ollama-agent/tasks/`:
 
@@ -381,11 +450,11 @@ reasoning_effort: "medium"
 
 ---
 
-## Agent Skills
+### Agent Skills Standard
 
 Ollama Agent supports the open [Agent Skills specification](https://agentskills.io/specification) powered by DeepAgents. Skills provide modular domain knowledge and specialized workflows through **progressive disclosure** — the agent inspects concise skill descriptions at prompt time and loads full instructions only when relevant.
 
-### Skill Directory Layout
+#### Skill Directory Layout
 
 Skills reside in `~/.ollama-agent/skills/<skill_id>/SKILL.md`:
 
@@ -398,7 +467,7 @@ Skills reside in `~/.ollama-agent/skills/<skill_id>/SKILL.md`:
     └── scraper.py
 ```
 
-### Example `SKILL.md`
+#### Example `SKILL.md`
 
 ```markdown
 ---
@@ -414,7 +483,7 @@ description: Guidelines and best practices for designing RESTful and OpenAPI com
 3. Ensure request/response schemas use JSON and camelCase properties.
 ```
 
-### Skill Management Commands
+#### Skill Management Commands
 
 | Action | REPL Command | CLI Command |
 | :--- | :--- | :--- |
@@ -428,11 +497,11 @@ description: Guidelines and best practices for designing RESTful and OpenAPI com
 
 ---
 
-## RAG (Retrieval Augmented Generation)
+### Local RAG (Retrieval Augmented Generation)
 
 Local RAG empowers the agent to index documents into local Qdrant vector databases and automatically retrieve relevant excerpts using Ollama embeddings.
 
-### 1. Managing Databases
+#### 1. Managing Databases
 
 ```bash
 # CLI: Create, list, and delete databases
@@ -443,12 +512,15 @@ ollama-agent rag-delete project-docs
 
 Inside REPL:
 ```text
+/rag status
 /rag create project-docs
 /rag list
+/rag load project-docs
+/rag unload
 /rag delete project-docs
 ```
 
-### 2. Indexing Documents
+#### 2. Indexing Documents
 
 ```bash
 # CLI: Index a single file or an entire directory
@@ -465,7 +537,7 @@ Inside REPL:
 
 **Supported File Formats**: `.py`, `.js`, `.ts`, `.tsx`, `.jsx`, `.sh`, `.yaml`, `.yml`, `.json`, `.xml`, `.md`, `.txt`, `.toml`, `.c`, `.cpp`, `.h`, `.hpp`, `.go`, `.rs`, `.css`, `.html`, `.sql`, `.ini`, `.cfg`, `.properties`, `.java`, `.kt`, `.gradle`, `.bat`, `.ps1`, `.csv`, `.rst`, plus text/json/xml MIME fallbacks.
 
-### 3. Automated RAG Retrieval
+#### 3. Automated RAG Retrieval
 
 When a database is loaded, the agent automatically gains access to the `rag_search` tool:
 - The system prompt is dynamically updated with RAG search instructions.
@@ -478,146 +550,6 @@ ollama-agent --rag project-docs
 # Non-interactive query against RAG database
 ollama-agent --rag project-docs -p "How is authentication handled in this project?"
 ```
-
----
-
-## Persistent Memory & Project Guidelines
-
-Ollama Agent automatically combines long-term cross-session memory with repository-specific coding standards.
-
-```mermaid
-flowchart TD
-    A[Agent Startup] --> B[1. Load Repository Guidelines\nAGENTS.md / agents.md up to .git root]
-    A --> C[2. Load Global User Guidelines\n~/.ollama-agent/AGENTS.md]
-    A --> D[3. Mount Cross-Session Memory\n~/.ollama-agent/MEMORY.md]
-    B & C & D --> E[Unified Agent Memory Context]
-```
-
-### 1. Repository Project Guidelines (`AGENTS.md`)
-The agent searches the current working directory and ascends parent directories up to the repository root (`.git`) for `AGENTS.md` (or `agents.md`, `.agents.md`). Discovered instructions are mounted directly into agent memory.
-
-### 2. Global Agent Guidelines (`~/.ollama-agent/AGENTS.md`)
-Initialized automatically by the runtime to maintain user-wide coding standards across all repositories and directories.
-
-### 3. Cross-Session Memory (`~/.ollama-agent/MEMORY.md`)
-Maintained by the agent across sessions to record user preferences, persistent architectural decisions, and project notes.
-
-### 4. Episodic Memory (`search_past_conversations`)
-Allows the AI agent to search and recall past conversation sessions, past troubleshooting steps, and previous architectural decisions stored in `~/.ollama-agent/history.db`:
-- **Autonomous Agent Tool**: The `search_past_conversations` tool is available to the agent so it can query prior sessions on demand when asked about past context.
-- **User Discovery**: Users can also search past sessions manually via `/session search <query>` in the REPL or `ollama-agent session-search <query>` in the CLI.
-
----
-
-## Configuration & Settings
-
-On initial launch, Ollama Agent generates its configuration directory at `~/.ollama-agent/` and initializes `settings.yaml`.
-
-### Configuration File (`settings.yaml`)
-
-```yaml
-model:
-  name: gemma4:26b
-  base_url: http://localhost:11434
-  temperature: 0.0
-  context_window: 10000
-  reasoning_effort: medium
-runtime:
-  allow_traversal: false
-  builtin_tool_timeout: 30
-  collapse_thinking: true
-  inherit_env: false
-rag:
-  rag_dir: ~/.ollama-agent/rag
-  embedder_model: nomic-embed-text:latest
-  embedder_base_url: http://localhost:11434
-  embedding_dims: 768
-  default_top_k: 5
-  chunk_size: 500
-  chunk_overlap: 50
-mentions:
-  max_file_size: 1048576
-  max_files: 100
-  max_total_size: 10485760
-  max_completions: 200
-subagents: []
-```
-
-### Settings Reference
-
-| Section & Key | Type | Default | Description |
-| :--- | :--- | :--- | :--- |
-| `model.name` | `str` | `gemma4:26b` | Default Ollama model name (must support tool calling). |
-| `model.base_url` | `str` | `http://localhost:11434` | Ollama native API endpoint. |
-| `model.temperature` | `float` | `0.0` | Sampling temperature for model responses. |
-| `model.context_window` | `int` | `10000` | Fallback context window token limit (`num_ctx`). |
-| `model.reasoning_effort` | `str` | `medium` | Default reasoning effort (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`). |
-| `runtime.allow_traversal` | `bool` | `false` | If true, permits filesystem operations outside project working directory. |
-| `runtime.builtin_tool_timeout` | `int` | `30` | Execution timeout in seconds for tool and shell commands. |
-| `runtime.collapse_thinking` | `bool` | `true` | If true, collapses reasoning blocks by default in REPL output. |
-| `runtime.inherit_env` | `bool` | `false` | If true, tool executions inherit the full parent environment. |
-| `rag.embedder_model` | `str` | `nomic-embed-text:latest` | Ollama model used to generate vector embeddings. |
-| `rag.embedding_dims` | `int` | `768` | Vector embedding dimension size. |
-| `rag.default_top_k` | `int` | `5` | Default number of relevant chunks retrieved per query. |
-| `rag.chunk_size` | `int` | `500` | Document chunk size in characters. |
-| `rag.chunk_overlap` | `int` | `50` | Character overlap between adjacent chunks. |
-| `mentions.max_file_size` | `int` | `1048576` | Maximum allowed individual file size for `@-mentions` (1 MB). |
-| `mentions.max_files` | `int` | `100` | Maximum number of files processed during directory mentions. |
-| `mentions.max_total_size` | `int` | `10485760` | Maximum total context size for prompt attachments (10 MB). |
-
----
-
-### Context Window Resolution
-
-The effective context window (`num_ctx`) is resolved automatically in the following hierarchy:
-
-1. `model.context_window` defined in `settings.yaml` (if configured > 0).
-2. Structured metadata from `ollama show <model>` (e.g. `llama.context_length`, `qwen2.context_length`).
-3. Modelfile parameter regex (`PARAMETER num_ctx <size>`) from `ollama show <model>`.
-4. If unresolved, the agent halts with a clear configuration prompt.
-
----
-
-### Configuration Reset (`--config-reset`)
-
-Reset configuration files or system prompts back to package defaults:
-
-```bash
-# Reset settings.yaml only
-ollama-agent --config-reset config-file
-
-# Reset all system prompts (instructions.md, fs_policy_sandboxed.md, fs_policy_traversal.md, rag_policy.md)
-ollama-agent --config-reset system-prompt
-
-# Reset both configuration and prompt files
-ollama-agent --config-reset all
-```
-
----
-
-### LangSmith Tracing
-
-Enable deep observability and execution tracing by adding the `langsmith` block to `~/.ollama-agent/settings.yaml`:
-
-```yaml
-langsmith:
-  api_key: "your-langsmith-api-key"
-  tracing: "true"
-  project: "ollama-agent"
-  endpoint: "https://api.smith.langchain.com"
-```
-
-When present, these values are automatically exported into the environment on startup.
-
----
-
-### Agent System Prompts
-
-System prompts are stored in `~/.ollama-agent/prompts/` and can be customized:
-- `instructions.md`: Main orchestrator behavioral instructions.
-- `fs_policy_sandboxed.md`: Virtual filesystem rules when sandboxed to project root.
-- `fs_policy_traversal.md`: Filesystem rules when traversal is enabled.
-- `rag_policy.md`: Instructions injected dynamically when a RAG database is active.
 
 ---
 
@@ -651,7 +583,7 @@ Create `~/.ollama-agent/mcp_servers.json`:
 ```
 
 - **Supported Transports**: `stdio` (subprocess execution) and `http` (remote endpoints).
-- **Environment Substitution**: `${VAR_NAME}` syntax automatically injects secrets from the host environment.
+- **Environment Substitution**: `${VAR_NAME}` (and `%VAR_NAME%`) syntax injects host environment variables; servers with missing required variables are skipped gracefully with a log warning.
 
 ---
 
@@ -681,6 +613,121 @@ subagents:
         command: "uvx"
         args: ["mcp-server-sqlite", "--db-path", "./data/analytics.db"]
 ```
+
+---
+
+## Configuration & Customization
+
+On initial launch, Ollama Agent generates its configuration directory at `~/.ollama-agent/` and initializes `settings.yaml`.
+
+### Configuration File (`settings.yaml`)
+
+```yaml
+model:
+  name: gemma4:26b
+  base_url: http://localhost:11434
+  temperature: 0.0
+  context_window: 10000
+  reasoning_effort: medium
+runtime:
+  allow_traversal: false
+  builtin_tool_timeout: 30
+  collapse_thinking: true
+  inherit_env: true
+rag:
+  rag_dir: ~/.ollama-agent/rag
+  embedder_model: nomic-embed-text:latest
+  embedder_base_url: http://localhost:11434
+  embedding_dims: 768
+  default_top_k: 5
+  chunk_size: 500
+  chunk_overlap: 50
+mentions:
+  max_file_size: 1048576
+  max_files: 100
+  max_total_size: 10485760
+  max_completions: 200
+subagents: []
+```
+
+### Settings Reference
+
+| Section & Key | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `model.name` | `str` | `gemma4:26b` | Default Ollama model name (must support tool calling). |
+| `model.base_url` | `str` | `http://localhost:11434` | Ollama native API endpoint. |
+| `model.temperature` | `float` | `0.0` | Sampling temperature for model responses. |
+| `model.context_window` | `int` | `10000` | Fallback context window token limit (`num_ctx`). |
+| `model.reasoning_effort` | `str` | `medium` | Default reasoning effort (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`). |
+| `runtime.allow_traversal` | `bool` | `false` | If true, permits filesystem operations outside project working directory. |
+| `runtime.builtin_tool_timeout` | `int` | `30` | Execution timeout in seconds for tool and shell commands. |
+| `runtime.collapse_thinking` | `bool` | `true` | If true, collapses reasoning blocks by default in REPL output. |
+| `runtime.inherit_env` | `bool` | `true` | If true, tool executions inherit the full parent environment. |
+| `rag.rag_dir` | `str` | `~/.ollama-agent/rag` | Storage directory for local RAG databases and vector indices. |
+| `rag.embedder_base_url` | `str` | `http://localhost:11434` | Ollama native API endpoint for embedding generation. |
+| `rag.embedder_model` | `str` | `nomic-embed-text:latest` | Ollama model used to generate vector embeddings. |
+| `rag.embedding_dims` | `int` | `768` | Vector embedding dimension size. |
+| `rag.default_top_k` | `int` | `5` | Default number of relevant chunks retrieved per query. |
+| `rag.chunk_size` | `int` | `500` | Document chunk size in characters. |
+| `rag.chunk_overlap` | `int` | `50` | Character overlap between adjacent chunks. |
+| `mentions.max_file_size` | `int` | `1048576` | Maximum allowed individual file size for `@-mentions` (1 MB). |
+| `mentions.max_files` | `int` | `100` | Maximum number of files processed during directory mentions. |
+| `mentions.max_total_size` | `int` | `10485760` | Maximum total context size for prompt attachments (10 MB). |
+| `mentions.max_completions` | `int` | `200` | Maximum autocompletion candidates for `@-mentions`. |
+
+---
+
+### Context Window Resolution
+
+The effective context window (`num_ctx`) is resolved automatically in the following hierarchy:
+
+1. `model.context_window` defined in `settings.yaml` (if configured > 0).
+2. Structured metadata from `ollama show <model>` (e.g. `llama.context_length`, `qwen2.context_length`).
+3. Modelfile parameter regex (`PARAMETER num_ctx <size>`) from `ollama show <model>`.
+4. If unresolved, the agent halts with a clear configuration prompt.
+
+---
+
+### Agent System Prompts
+
+System prompts are stored in `~/.ollama-agent/prompts/` and can be customized:
+- `instructions.md`: Main orchestrator behavioral instructions.
+- `fs_policy_sandboxed.md`: Virtual filesystem rules when sandboxed to project root.
+- `fs_policy_traversal.md`: Filesystem rules when traversal is enabled.
+- `rag_policy.md`: Instructions injected dynamically when a RAG database is active.
+
+---
+
+### Configuration Reset (`--config-reset`)
+
+Reset configuration files or system prompts back to package defaults:
+
+```bash
+# Reset settings.yaml only
+ollama-agent --config-reset config-file
+
+# Reset all system prompts (instructions.md, fs_policy_sandboxed.md, fs_policy_traversal.md, rag_policy.md)
+ollama-agent --config-reset system-prompt
+
+# Reset both configuration and prompt files
+ollama-agent --config-reset all
+```
+
+---
+
+### LangSmith Tracing
+
+Enable deep observability and execution tracing by adding the `langsmith` block to `~/.ollama-agent/settings.yaml`:
+
+```yaml
+langsmith:
+  api_key: "your-langsmith-api-key"
+  tracing: "true"
+  project: "ollama-agent"
+  endpoint: "https://api.smith.langchain.com"
+```
+
+When present, these values are automatically exported into the environment on startup.
 
 ---
 
@@ -730,8 +777,12 @@ ollama-agent/
 │   ├── streaming/           # Live console token streaming and non-interactive output
 │   └── tasks/               # YAML task repository and execution handlers
 ├── tests/                   # Automated unit and integration test suite
+├── docs/                    # MkDocs documentation source files
+├── mkdocs.yml               # MkDocs site configuration
 ├── pyproject.toml           # Project dependencies and packaging metadata
 ├── AGENTS.md                # Development guidelines and coding conventions
+├── MCP_COMPATIBILITY.md     # Dependency constraint documentation for MCP
+├── LICENSE                  # MIT license file
 └── README.md                # Project documentation
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 - 📋 **Saved Tasks**: Save reusable prompts as YAML templates and execute them on demand via CLI (`task-run`) or interactive REPL modals (`/task run`).
 - 🧩 **Agent Skills Standard**: Extend the agent with modular skills following the [Agent Skills specification](https://agentskills.io/specification) using progressive disclosure.
 - 📚 **Local RAG Engine**: Embed and index documents into local Qdrant vector collections with automated semantic retrieval via the agent's `rag_search` tool.
-- 🧠 **Persistent Memory & `AGENTS.md`**: Cross-session user memory (`MEMORY.md`) and automatic discovery of project-level guidelines (`AGENTS.md`) up to the repository root.
+- 🧠 **Persistent Memory & Guidelines**: Cross-session user memory (`MEMORY.md`), automatic discovery of project-level guidelines (`AGENTS.md`), and **Episodic Memory** to search past conversations and solutions (`search_past_conversations` tool and `/session search`).
 - 🔌 **Model Context Protocol (MCP)**: Attach MCP servers (`mcp_servers.json`) directly to the main agent across `stdio` and `http` transports.
 - 🤖 **Specialized Subagents**: Configure isolated subagents in `settings.yaml` with their own model, system prompt, and dedicated MCP tool servers.
 
@@ -140,7 +140,7 @@ The REPL provides built-in slash commands for managing models, sessions, tasks, 
 | :--- | :--- | :--- |
 | `/help` | `/help` | Display the interactive help panel with command categories. |
 | `/model` | `/model [list \| set <model>]` | List available Ollama models (with tool support indicators) or switch the active model for the current session. |
-| `/session` | `/session [list \| resume <id> \| new \| export [path] \| delete <id>]` | Manage persistent chat sessions. Resume previous conversations, export to Markdown, or delete history. |
+| `/session` | `/session [list \| search <query> \| resume <id> \| new \| export [path] \| delete <id>]` | Manage persistent chat sessions. Search past conversations, resume previous threads, export to Markdown, or delete history. |
 | `/compact` | `/compact` (alias: `/compress`) | Manually compact conversation history into a structured summary to reclaim context window tokens. |
 | `/task` | `/task [list \| create <id> \| run <id> [-y] \| delete <id>]` | Manage saved prompt tasks. Opens interactive modal dialogs for task creation. |
 | `/skill` | `/skill [list \| show <id> \| create <id> \| delete <id>]` | Manage agent skills. Opens interactive modal dialogs for skill creation. |
@@ -327,6 +327,7 @@ All conversations are saved to a local SQLite database at `~/.ollama-agent/histo
 | Action | REPL Command | CLI Command | Description |
 | :--- | :--- | :--- | :--- |
 | **List Sessions** | `/session list` | `ollama-agent session-list` | Display saved sessions with thread IDs, message counts, and active status. |
+| **Search Sessions** | `/session search <query>` | `ollama-agent session-search <query>` | Search across past chat sessions and conversations by keyword. |
 | **Resume Session** | `/session resume <id>` | — | Resume a past conversation by exact ID or prefix, restoring message history into the viewport. |
 | **New Session** | `/session new` (or `/new`) | — | Initialize a fresh conversation session with a new thread ID. |
 | **Export Session** | `/session export [path]` | `ollama-agent session-export <id> [-o path]` | Export conversation history to a structured Markdown document. |
@@ -500,6 +501,11 @@ Initialized automatically by the runtime to maintain user-wide coding standards 
 
 ### 3. Cross-Session Memory (`~/.ollama-agent/MEMORY.md`)
 Maintained by the agent across sessions to record user preferences, persistent architectural decisions, and project notes.
+
+### 4. Episodic Memory (`search_past_conversations`)
+Allows the AI agent to search and recall past conversation sessions, past troubleshooting steps, and previous architectural decisions stored in `~/.ollama-agent/history.db`:
+- **Autonomous Agent Tool**: The `search_past_conversations` tool is available to the agent so it can query prior sessions on demand when asked about past context.
+- **User Discovery**: Users can also search past sessions manually via `/session search <query>` in the REPL or `ollama-agent session-search <query>` in the CLI.
 
 ---
 

--- a/docs/cli_repl.md
+++ b/docs/cli_repl.md
@@ -294,14 +294,11 @@ The `--effort` flag (and `model.reasoning_effort` in `settings.yaml`) controls m
 
 | Model Family | `--effort` Value | Ollama API Parameter | Behavior |
 | :--- | :--- | :--- | :--- |
-| **Qwen 3.8** | `xhigh` / `medium` / `low` | `"xhigh"` / `"medium"` / `"low"` | Sets reasoning depth and controls cost (`xhigh` [default]: complex tasks demanding thorough analysis; `medium`: balancing accuracy and speed; `low`: efficient reasoning optimizing for speed and cost). |
-| **Qwen 3.8** | `high` / `enabled` | `"xhigh"` | Enables reasoning with default `xhigh` level. |
-| **Qwen 3.8** | `hide` | `"xhigh"` | Generates reasoning trace at default level but collapses/hides it from the UI. |
-| **Qwen 3.8** | `disabled` | `false` | Disables reasoning trace generation at the model level. |
-| **GPT-OSS** | `low` / `medium` / `high` | `"low"` / `"medium"` / `"high"` | Sets thinking trace depth. GPT-OSS accepts string effort levels. |
-| **GPT-OSS** | `disabled` / `hide` | *(omitted)* | GPT-OSS cannot disable thinking; emits warning, uses default effort, and hides reasoning trace in UI. |
+| **GPT-OSS** | `low` / `medium` / `high` / `xhigh` | `"low"` / `"medium"` / `"high"` / `"xhigh"` | Sets thinking trace depth. GPT-OSS accepts string effort levels. |
 | **GPT-OSS** | `enabled` | `"medium"` | Enables thinking with default `medium` level. |
-| **Other Reasoning Models**<br>*(Qwen 3, DeepSeek R1, DeepSeek-v3.1)* | `low` / `medium` / `high` / `xhigh` / `enabled` | `true` | Enables native reasoning generation. |
-| **Other Reasoning Models** | `hide` | `true` | Generates reasoning trace but collapses/hides it from the UI. |
-| **Other Reasoning Models** | `disabled` | `false` | Disables reasoning trace generation at the model level. |
+| **GPT-OSS** | `hide` | *(omitted)* | Uses model default effort and hides reasoning trace in UI. |
+| **GPT-OSS** | `disabled` | *(omitted)* | GPT-OSS cannot disable thinking; emits warning, uses default effort, and hides reasoning trace in UI. |
+| **Reasoning Models**<br>*(Qwen 2.5/3, DeepSeek R1, DeepSeek-v3.1)* | `low` / `medium` / `high` / `xhigh` / `enabled` | `true` | Enables native reasoning generation. |
+| **Reasoning Models** | `hide` | `true` | Generates reasoning trace but collapses/hides it from the UI. |
+| **Reasoning Models** | `disabled` | `false` | Disables reasoning trace generation at the model level. |
 | **Non-Thinking Models** | *(any)* | *(omitted)* | Setting is ignored gracefully. |

--- a/docs/cli_repl.md
+++ b/docs/cli_repl.md
@@ -122,6 +122,9 @@ ollama-agent skill-delete api-design
 # List all saved chat sessions with step counts
 ollama-agent session-list
 
+# Search past sessions by keyword
+ollama-agent session-search "dockerize fastapi"
+
 # Export a session to a Markdown document
 ollama-agent session-export 4d7e2a1b -o ./exports/session_summary.md
 
@@ -147,7 +150,7 @@ Slash commands provide full application control directly within the REPL:
 | :--- | :--- | :--- |
 | `/help` | `/help` | Display interactive help panel categorized by feature. |
 | `/model` | `/model [list \| set <model>]` | List available Ollama models (with tool support indicators) or switch model mid-session. |
-| `/session` | `/session [list \| resume <id> \| new \| export [path] \| delete <id>]` | Manage persistent chat sessions. Resume conversations, export to Markdown, or delete history. |
+| `/session` | `/session [list \| search <query> \| resume <id> \| new \| export [path] \| delete <id>]` | Manage persistent chat sessions. Search past conversations, resume threads, export to Markdown, or delete history. |
 | `/compact` | `/compact` (alias: `/compress`) | Manually compact conversation history into a structured summary to reclaim context window tokens. |
 | `/task` | `/task [list \| create <id> \| run <id> [-y] \| delete <id>]` | Manage saved prompt tasks. `/task create` launches an interactive modal dialog. |
 | `/skill` | `/skill [list \| show <id> \| create <id> \| delete <id>]` | Manage agent skills. `/skill create` launches an interactive modal dialog. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ runtime:
   allow_traversal: false                 # Allow agent filesystem traversal outside the working directory
   builtin_tool_timeout: 30               # Tool execution timeout in seconds
   collapse_thinking: true                # Automatically collapse thinking blocks in REPL TUI
-  inherit_env: false                     # Inherit shell environment variables for executed commands
+  inherit_env: true                      # Inherit shell environment variables for executed commands
 
 # RAG (Retrieval-Augmented Generation) Vector Database Settings
 rag:
@@ -80,7 +80,7 @@ subagents:
 | `runtime.allow_traversal` | `bool` | `false` | If true, permits filesystem operations outside project working directory. |
 | `runtime.builtin_tool_timeout` | `int` | `30` | Execution timeout in seconds for tool and shell commands. |
 | `runtime.collapse_thinking` | `bool` | `true` | If true, collapses reasoning blocks by default in REPL output. |
-| `runtime.inherit_env` | `bool` | `false` | If true, tool executions inherit the full parent environment. |
+| `runtime.inherit_env` | `bool` | `true` | If true, tool executions inherit the full parent environment. |
 | `rag.rag_dir` | `str` | `~/.ollama-agent/rag` | Directory storing local Qdrant vector database collections. |
 | `rag.embedder_model` | `str` | `nomic-embed-text:latest` | Ollama model used to generate vector embeddings. |
 | `rag.embedder_base_url` | `str` | `http://localhost:11434` | Endpoint for Ollama embeddings inference. |
@@ -141,16 +141,13 @@ The `--effort` flag and `model.reasoning_effort` setting control model reasoning
 
 | Model Family | `--effort` Value | Ollama API Parameter | Behavior |
 | :--- | :--- | :--- | :--- |
-| **Qwen 3.8** | `xhigh` / `medium` / `low` | `"xhigh"` / `"medium"` / `"low"` | Sets reasoning depth and controls cost (`xhigh` [default]: complex tasks demanding thorough analysis; `medium`: balancing accuracy and speed; `low`: efficient reasoning optimizing for speed and cost). |
-| **Qwen 3.8** | `high` / `enabled` | `"xhigh"` | Enables reasoning with default `xhigh` level. |
-| **Qwen 3.8** | `hide` | `"xhigh"` | Generates reasoning trace at default level but collapses/hides it from the UI. |
-| **Qwen 3.8** | `disabled` | `false` | Disables reasoning trace generation at the model level. |
-| **GPT-OSS** | `low` / `medium` / `high` | `"low"` / `"medium"` / `"high"` | Sets thinking trace depth string. |
-| **GPT-OSS** | `disabled` / `hide` | *(omitted)* | GPT-OSS cannot disable thinking; emits warning, uses default effort, and hides reasoning trace in UI. |
+| **GPT-OSS** | `low` / `medium` / `high` / `xhigh` | `"low"` / `"medium"` / `"high"` / `"xhigh"` | Sets thinking trace depth string. |
 | **GPT-OSS** | `enabled` | `"medium"` | Enables thinking with default `medium` level. |
-| **Other Reasoning Models**<br>*(Qwen 3, DeepSeek R1, DeepSeek-v3.1)* | `low` / `medium` / `high` / `xhigh` / `enabled` | `true` | Enables native reasoning generation. |
-| **Other Reasoning Models** | `hide` | `true` | Generates reasoning trace but collapses/hides it from the UI. |
-| **Other Reasoning Models** | `disabled` | `false` | Disables reasoning trace generation at the model level. |
+| **GPT-OSS** | `hide` | *(omitted)* | Uses model default effort and hides reasoning trace in UI. |
+| **GPT-OSS** | `disabled` | *(omitted)* | GPT-OSS cannot disable thinking; emits warning, uses default effort, and hides reasoning trace in UI. |
+| **Reasoning Models**<br>*(Qwen 2.5/3, DeepSeek R1, DeepSeek-v3.1)* | `low` / `medium` / `high` / `xhigh` / `enabled` | `true` | Enables native reasoning generation. |
+| **Reasoning Models** | `hide` | `true` | Generates reasoning trace but collapses/hides it from the UI. |
+| **Reasoning Models** | `disabled` | `false` | Disables reasoning trace generation at the model level. |
 | **Non-Thinking Models** | *(any)* | *(omitted)* | Setting is ignored gracefully. |
 
 ---

--- a/docs/skills_tasks_memory.md
+++ b/docs/skills_tasks_memory.md
@@ -1,11 +1,12 @@
 # Skills, Tasks & Persistent Memory (`AGENTS.md` & `MEMORY.md`)
 
-This document covers four core capabilities that enable `ollama-agent` to adapt, automate repetitive routines, retain project context, and preserve long-term user memory:
+This document covers core capabilities that enable `ollama-agent` to adapt, automate repetitive routines, retain project context, preserve long-term user memory, and recall past experiences:
 
 1. **Agent Skills System** (Adhering to the Agent Skills specification)
 2. **Task Automation System** (Pre-configured prompt templates and models)
 3. **Project Agent Guidelines** (`AGENTS.md` standard integration)
 4. **Long-Term Persistent Memory** (`MEMORY.md` cross-session integration)
+5. **Episodic Memory & Past Conversations** (`search_past_conversations` tool and `/session search`)
 
 ---
 
@@ -169,3 +170,28 @@ sequenceDiagram
 - **Reading**: The agent automatically reads memory and project guidelines at the start of each execution turn via `MemoryMiddleware`.
 - **Writing**: The agent edits `/agent/MEMORY.md` or `/AGENTS.md` directly using file editing tools when instructed to record new preferences or architectural patterns.
 - **Persistence**: Memory persists across system restarts, terminal sessions, and model switches.
+
+---
+
+## 5. Episodic Memory & Past Conversations
+
+Episodic memory captures records of past experiences, decisions, and troubleshooting dialogues across conversation threads. Unlike semantic memory (which distills preferences into files like `MEMORY.md`), episodic memory preserves conversation turns and actions so the agent can look back at *how* problems were solved previously.
+
+### Autonomous Episodic Tool: `search_past_conversations`
+
+The agent is equipped with the built-in tool `search_past_conversations(query: str, limit: int = 3)`.
+
+- **Mechanism**: Reads serialized message checkpoints directly from `~/.ollama-agent/history.db` (`writes` table) using `JsonPlusSerializer`.
+- **Active Thread Exclusion**: Automatically skips the current active session to avoid duplicating short-term memory.
+- **Keyword & Topic Matching**: Analyzes user prompts and assistant actions across past threads, ranking matches by relevance score.
+- **Structured Context**: Formats the matched sessions into clean Markdown excerpts for the LLM.
+
+### User Search Commands (CLI & REPL)
+
+Users can search conversation history directly from the terminal:
+
+| Interface | Command | Description |
+| :--- | :--- | :--- |
+| **REPL Slash Command** | `/session search <query>` | Search all saved chat sessions and display matching snippets in a Rich table. |
+| **CLI Command** | `ollama-agent session-search <query>` | Query past sessions non-interactively from the shell. |
+| **Resume Matched Session** | `/session resume <id>` | Resume a discovered session by thread ID. |

--- a/ollama_agent/agent/__init__.py
+++ b/ollama_agent/agent/__init__.py
@@ -6,6 +6,7 @@ from .builtin_tools import (
     get_rag_manager,
     get_tool_timeout,
     rag_search,
+    search_past_conversations,
     set_rag_manager,
     set_tool_timeout,
 )
@@ -16,6 +17,7 @@ __all__ = [
     "get_rag_manager",
     "get_tool_timeout",
     "rag_search",
+    "search_past_conversations",
     "set_rag_manager",
     "set_tool_timeout",
 ]

--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -48,7 +48,13 @@ from ..settings import (
     save_settings,
 )
 from ..streaming.parsers import streaming_reasoning, streaming_text
-from .builtin_tools import BUILTIN_TOOLS, get_rag_manager, get_tool_timeout, rag_search
+from .builtin_tools import (
+    BUILTIN_TOOLS,
+    get_rag_manager,
+    get_tool_timeout,
+    rag_search,
+    set_active_thread_id,
+)
 from .middleware import stream_tool_events_mw
 from .subagents import build_subagents
 
@@ -255,6 +261,7 @@ class AgentRuntime:
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Stream agent events for the given prompt."""
         thread = thread_id or self.thread_id
+        set_active_thread_id(thread)
         if self.graph is None:
             await self.reload()
         assert self.graph is not None

--- a/ollama_agent/agent/builtin_tools.py
+++ b/ollama_agent/agent/builtin_tools.py
@@ -9,10 +9,15 @@ from langchain.tools import tool
 
 from ..core import RAGToolResult
 from ..rag import RAGError, RAGManager
+from .episodic_memory import (
+    format_past_conversations_context,
+    search_past_conversations_in_db,
+)
 
 
 _tool_timeout: ContextVar[int] = ContextVar("tool_timeout", default=30)
 _rag_manager: ContextVar[RAGManager | None] = ContextVar("rag_manager", default=None)
+_active_thread_id: ContextVar[str] = ContextVar("active_thread_id", default="")
 
 
 def set_tool_timeout(timeout: int) -> None:
@@ -29,6 +34,14 @@ def set_rag_manager(mgr: RAGManager | None) -> None:
 
 def get_rag_manager() -> RAGManager | None:
     return _rag_manager.get()
+
+
+def set_active_thread_id(thread_id: str) -> None:
+    _active_thread_id.set(thread_id)
+
+
+def get_active_thread_id() -> str:
+    return _active_thread_id.get()
 
 
 @tool
@@ -53,5 +66,17 @@ async def rag_search(query: str, top_k: int | None = None) -> RAGToolResult:
         return {"success": False, "error": str(exc)}
 
 
-BUILTIN_TOOLS: list[Any] = []
+@tool
+async def search_past_conversations(query: str, limit: int = 3) -> str:
+    """Search past conversation sessions and episodic memory for relevant solutions, decisions, or context."""
+    results = search_past_conversations_in_db(
+        query=query,
+        exclude_thread_id=get_active_thread_id(),
+        limit=limit,
+    )
+    return format_past_conversations_context(results)
+
+
+BUILTIN_TOOLS: list[Any] = [search_past_conversations]
+
 

--- a/ollama_agent/agent/episodic_memory.py
+++ b/ollama_agent/agent/episodic_memory.py
@@ -1,0 +1,121 @@
+"""Episodic memory search engine for past agent conversations and experiences."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+from ..core.common import extract_text
+from ..settings.paths import HISTORY_DB_PATH
+
+_serializer = JsonPlusSerializer()
+
+
+def load_past_conversations(
+    db_path: Path = HISTORY_DB_PATH,
+    exclude_thread_id: str = "",
+) -> dict[str, list[Any]]:
+    """Load conversation messages grouped by thread_id from SQLite history.
+
+    Threads matching ``exclude_thread_id`` (e.g. active conversation) are skipped.
+    """
+    if not db_path.exists():
+        return {}
+
+    conversations: dict[str, list[Any]] = {}
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT thread_id, type, value FROM writes WHERE channel = 'messages' ORDER BY rowid ASC"
+        )
+        rows = cursor.fetchall()
+
+    for tid, typ, val in rows:
+        if exclude_thread_id and (tid == exclude_thread_id or tid.startswith(exclude_thread_id)):
+            continue
+        msgs = _serializer.loads_typed((typ, val))
+        if tid not in conversations:
+            conversations[tid] = []
+        if isinstance(msgs, list):
+            conversations[tid].extend(msgs)
+        else:
+            conversations[tid].append(msgs)
+
+    return conversations
+
+
+def search_past_conversations_in_db(
+    query: str,
+    db_path: Path = HISTORY_DB_PATH,
+    exclude_thread_id: str = "",
+    limit: int = 3,
+) -> list[dict[str, Any]]:
+    """Search messages across past conversation sessions matching query keywords."""
+    clean_query = query.strip()
+    if not clean_query:
+        return []
+
+    conversations = load_past_conversations(db_path, exclude_thread_id=exclude_thread_id)
+    if not conversations:
+        return []
+
+    terms = [t.lower() for t in clean_query.split() if t]
+    scored_results: list[dict[str, Any]] = []
+
+    for tid, msgs in conversations.items():
+        if not msgs:
+            continue
+
+        snippets: list[str] = []
+        match_count = 0
+        total_chars = 0
+
+        for msg in msgs:
+            role = msg.type
+            text = extract_text(msg.content).strip()
+            if not text:
+                continue
+
+            text_lower = text.lower()
+            term_hits = sum(text_lower.count(t) for t in terms)
+            if term_hits > 0:
+                match_count += term_hits
+                truncated = text if len(text) <= 300 else f"{text[:297]}..."
+                role_label = "User" if role == "human" else ("Assistant" if role == "ai" else role)
+                snippets.append(f"[{role_label}]: {truncated}")
+                total_chars += len(truncated)
+                if total_chars > 1200:
+                    break
+
+        if match_count > 0 and snippets:
+            scored_results.append({
+                "thread_id": tid,
+                "score": match_count,
+                "snippets": snippets,
+                "total_messages": len(msgs),
+            })
+
+    scored_results.sort(key=lambda item: item["score"], reverse=True)
+    return scored_results[:max(1, limit)]
+
+
+def format_past_conversations_context(results: list[dict[str, Any]]) -> str:
+    """Format matching episodic conversation sessions into a markdown context string."""
+    if not results:
+        return "No relevant past conversations found in episodic memory."
+
+    lines: list[str] = [
+        f"Found {len(results)} relevant past conversation(s) in episodic memory:\n"
+    ]
+    for idx, item in enumerate(results, start=1):
+        tid = item["thread_id"]
+        short_id = tid[:8]
+        lines.append(f"### Session #{idx} ({short_id}) - [Total messages: {item['total_messages']}]")
+        for snippet in item["snippets"]:
+            lines.append(f"  {snippet}")
+        lines.append("")
+
+    return "\n".join(lines).strip()

--- a/ollama_agent/interfaces/cli.py
+++ b/ollama_agent/interfaces/cli.py
@@ -172,6 +172,11 @@ def _add_task_subcommands(parser: argparse.ArgumentParser) -> None:
     # Session subcommands
     _add_subparser(subparsers, "session-list", "List all past chat sessions")
 
+    session_search = _add_subparser(
+        subparsers, "session-search", "Search past chat sessions by query keyword"
+    )
+    session_search.add_argument("query", type=str, help="Search query string")
+
     session_del = _add_subparser(subparsers, "session-delete", "Delete a chat session from history")
     session_del.add_argument("session_id", type=str, help="Session ID or prefix to delete")
 

--- a/ollama_agent/interfaces/dispatch.py
+++ b/ollama_agent/interfaces/dispatch.py
@@ -33,6 +33,7 @@ from .session_commands import (
     list_sessions,
     new_session,
     resume_session,
+    search_sessions,
 )
 
 CLIHandler = Callable[[], object]
@@ -123,6 +124,7 @@ def build_cli_handlers(
             force=args.force,
         ),
         "session-list": lambda: list_sessions(Console()),
+        "session-search": lambda: search_sessions(Console(), args.query),
         "session-delete": lambda: delete_session(Console(), args.session_id),
         "session-export": lambda: _cli_export_session(
             Console(),
@@ -261,12 +263,21 @@ def build_repl_handlers(
                 return handle_session_export(args[1:])
             console.print("[red]Export not available in current context.[/red]")
             return None
+        if sub == "search":
+            if len(args) < 2:
+                console.print("[red]Usage: /session search <query>[/red]")
+                return None
+            return search_sessions(
+                console,
+                " ".join(args[1:]),
+                current_thread_id=current_thread_id(),
+            )
         if sub == "delete":
             if len(args) < 2:
                 console.print("[red]Usage: /session delete <session_id>[/red]")
                 return None
             return delete_session(console, args[1])
-        console.print(f"[red]Unknown session subcommand '{sub}'. Usage: /session [list | resume <id> | new | export [path] | delete <id>][/red]")
+        console.print(f"[red]Unknown session subcommand '{sub}'. Usage: /session [list | search <query> | resume <id> | new | export [path] | delete <id>][/red]")
         return None
 
     cmds: dict[str, REPLCommand] = {

--- a/ollama_agent/interfaces/session_commands.py
+++ b/ollama_agent/interfaces/session_commands.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from rich.console import Console
 from rich.table import Table
 
+from ..agent.episodic_memory import search_past_conversations_in_db
 from ..core.common import extract_text
 from ..settings.paths import HISTORY_DB_PATH
 
@@ -219,3 +220,45 @@ async def compact_session(
     else:
         console.print(f"[yellow]{res.get('message', 'Compaction failed.')}[/yellow]")
     return res
+
+
+def search_sessions(
+    console: Console,
+    query: str,
+    db_path: Path = HISTORY_DB_PATH,
+    current_thread_id: str = "",
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Search chat sessions matching query keywords and display formatted results."""
+    clean_query = query.strip()
+    if not clean_query:
+        console.print("[yellow]Please provide a search query.[/yellow]")
+        return []
+
+    results = search_past_conversations_in_db(
+        query=clean_query,
+        db_path=db_path,
+        exclude_thread_id="",
+        limit=limit,
+    )
+    if not results:
+        console.print(f"[yellow]No sessions found matching '[bold]{clean_query}[/bold]'.[/yellow]")
+        return []
+
+    table = Table(title=f"Search Results for '{clean_query}'", header_style="bold cyan")
+    table.add_column("Session ID", style="bold", width=14)
+    table.add_column("Score", justify="right", width=6)
+    table.add_column("Snippet Preview", justify="left")
+
+    for item in results:
+        tid = item["thread_id"]
+        is_current = tid == current_thread_id or (current_thread_id and tid.startswith(current_thread_id))
+        tid_display = f"{tid[:8]}" + (" [green]◀ current[/green]" if is_current else "")
+        score_display = str(item["score"])
+        snippets_display = "\n".join(item["snippets"][:2])
+        table.add_row(tid_display, score_display, snippets_display)
+
+    console.print(table)
+    console.print("[dim]Use /session resume <id> to switch to a matched session.[/dim]")
+    return results
+

--- a/ollama_agent/settings/prompts/default_instructions.md
+++ b/ollama_agent/settings/prompts/default_instructions.md
@@ -4,7 +4,7 @@ You are an AI Assistant.
 Solve the user's task efficiently and transparently. Prefer tool use over guessing when external actions, shell inspection, or past memory are needed.
 
 # MEMORY GUIDELINES
-- **Updating Long-Term Memory (`/agent/MEMORY.md`)**: Guidelines and memories from `AGENTS.md` and `MEMORY.md` are loaded into context automatically. When the user explicitly instructs you to remember a preference, convention, or fact (e.g., "remember that...", "save this preference"), use `edit_file` or `write_file` to persist it in `/agent/MEMORY.md`. Keep entries concise and structured.
+- **Updating Long-Term Memory (`/agent/MEMORY.md`)**: When the user explicitly instructs you to remember a preference, convention, or fact (e.g., "remember that...", "save this preference"), use `edit_file` or `write_file` to persist it in `/agent/MEMORY.md`. Keep entries concise and structured.
 - **Recalling Past Conversations (`search_past_conversations`)**: Use the `search_past_conversations` tool when the user asks about prior sessions, past debugging steps, or earlier decisions (e.g., "how did we solve X before?", "what did we do last time?").
 
 

--- a/ollama_agent/settings/prompts/default_instructions.md
+++ b/ollama_agent/settings/prompts/default_instructions.md
@@ -3,24 +3,9 @@ You are an AI Assistant.
 # CORE OBJECTIVE
 Solve the user's task efficiently and transparently. Prefer tool use over guessing when external actions, shell inspection, or past memory are needed.
 
-# MEMORY SYSTEM
-You have access to different memory layers to assist the user effectively:
-
-1. **Short-Term Memory (Current Session)**:
-   - Retains the immediate multi-turn conversation in the active thread.
-
-2. **Long-Term Semantic Memory (`/agent/MEMORY.md` & `AGENTS.md`)**:
-   - `/agent/MEMORY.md`: Stores persistent user preferences, conventions, and long-term notes across sessions. When the user asks you to remember a preference, rule, or fact, update `/agent/MEMORY.md` using file editing tools (`edit_file` / `write_file`).
-   - `/AGENTS.md` (or `/project/AGENTS.md`): Contains project-level coding guidelines and repository instructions.
-   - `/agent/AGENTS.md`: Contains global user guidelines.
-
-3. **Procedural Memory (Skills at `/skills/`)**:
-   - Contains reusable instructions and specialized workflows. Read `/skills/<skill_id>/SKILL.md` on-demand when a task matches a skill's description.
-
-4. **Episodic Memory (`search_past_conversations` tool)**:
-   - Allows searching through past conversation sessions, past troubleshooting steps, and previous decisions.
-   - Use `search_past_conversations` when the user asks about previous sessions, past debugging solutions, decisions made earlier, or mentions "how we did X before".
-   - Do not search past conversations for the current conversation's immediate context.
+# MEMORY GUIDELINES
+- **Updating Long-Term Memory (`/agent/MEMORY.md`)**: Guidelines and memories from `AGENTS.md` and `MEMORY.md` are loaded into context automatically. When the user explicitly instructs you to remember a preference, convention, or fact (e.g., "remember that...", "save this preference"), use `edit_file` or `write_file` to persist it in `/agent/MEMORY.md`. Keep entries concise and structured.
+- **Recalling Past Conversations (`search_past_conversations`)**: Use the `search_past_conversations` tool when the user asks about prior sessions, past debugging steps, or earlier decisions (e.g., "how did we solve X before?", "what did we do last time?").
 
 
 {FILESYSTEM_POLICY}

--- a/ollama_agent/settings/prompts/default_instructions.md
+++ b/ollama_agent/settings/prompts/default_instructions.md
@@ -3,6 +3,25 @@ You are an AI Assistant.
 # CORE OBJECTIVE
 Solve the user's task efficiently and transparently. Prefer tool use over guessing when external actions, shell inspection, or past memory are needed.
 
+# MEMORY SYSTEM
+You have access to different memory layers to assist the user effectively:
+
+1. **Short-Term Memory (Current Session)**:
+   - Retains the immediate multi-turn conversation in the active thread.
+
+2. **Long-Term Semantic Memory (`/agent/MEMORY.md` & `AGENTS.md`)**:
+   - `/agent/MEMORY.md`: Stores persistent user preferences, conventions, and long-term notes across sessions. When the user asks you to remember a preference, rule, or fact, update `/agent/MEMORY.md` using file editing tools (`edit_file` / `write_file`).
+   - `/AGENTS.md` (or `/project/AGENTS.md`): Contains project-level coding guidelines and repository instructions.
+   - `/agent/AGENTS.md`: Contains global user guidelines.
+
+3. **Procedural Memory (Skills at `/skills/`)**:
+   - Contains reusable instructions and specialized workflows. Read `/skills/<skill_id>/SKILL.md` on-demand when a task matches a skill's description.
+
+4. **Episodic Memory (`search_past_conversations` tool)**:
+   - Allows searching through past conversation sessions, past troubleshooting steps, and previous decisions.
+   - Use `search_past_conversations` when the user asks about previous sessions, past debugging solutions, decisions made earlier, or mentions "how we did X before".
+   - Do not search past conversations for the current conversation's immediate context.
+
 
 {FILESYSTEM_POLICY}
 

--- a/tests/test_episodic_memory.py
+++ b/tests/test_episodic_memory.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+from ollama_agent.agent.builtin_tools import (
+    get_active_thread_id,
+    search_past_conversations,
+    set_active_thread_id,
+)
+from ollama_agent.agent.episodic_memory import (
+    format_past_conversations_context,
+    load_past_conversations,
+    search_past_conversations_in_db,
+)
+
+
+class TestEpisodicMemory(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for episodic memory loading, keyword search, and formatting."""
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmpdir.name) / "history.db"
+        self.serializer = JsonPlusSerializer()
+        set_active_thread_id("")
+
+    def tearDown(self) -> None:
+        set_active_thread_id("")
+        self.tmpdir.cleanup()
+
+    def _seed_db(self) -> None:
+        conn = sqlite3.connect(str(self.db_path))
+        cur = conn.cursor()
+        cur.execute(
+            """CREATE TABLE writes (
+                thread_id TEXT,
+                checkpoint_ns TEXT DEFAULT '',
+                checkpoint_id TEXT,
+                task_id TEXT,
+                idx INTEGER,
+                channel TEXT,
+                type TEXT,
+                value BLOB
+            );"""
+        )
+
+        # Thread 1: FastApi and Docker discussion
+        t1_msgs = [
+            HumanMessage(content="How do I dockerize a FastAPI application?"),
+            AIMessage(content="You should create a Dockerfile using python:3.11-slim and install uvicorn."),
+        ]
+        typ1, val1 = self.serializer.dumps_typed(t1_msgs)
+        cur.execute(
+            "INSERT INTO writes (thread_id, checkpoint_id, task_id, idx, channel, type, value) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("thread-100", "cp-1", "task-1", 0, "messages", typ1, val1),
+        )
+
+        # Thread 2: React frontend setup
+        t2_msgs = [
+            HumanMessage(content="Set up a React Vite project with TypeScript."),
+            AIMessage(content="Run npm create vite@latest my-app -- --template react-ts."),
+        ]
+        typ2, val2 = self.serializer.dumps_typed(t2_msgs)
+        cur.execute(
+            "INSERT INTO writes (thread_id, checkpoint_id, task_id, idx, channel, type, value) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("thread-200", "cp-2", "task-2", 0, "messages", typ2, val2),
+        )
+
+        # Thread 3: PostgreSQL and Alembic migrations
+        t3_msgs = [
+            HumanMessage(content="How to handle PostgreSQL migrations with Alembic?"),
+            AIMessage(content="Run alembic revision --autogenerate and alembic upgrade head."),
+            ToolMessage(content="Migration output: success", tool_call_id="call-1"),
+        ]
+        typ3, val3 = self.serializer.dumps_typed(t3_msgs)
+        cur.execute(
+            "INSERT INTO writes (thread_id, checkpoint_id, task_id, idx, channel, type, value) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("thread-300", "cp-3", "task-3", 0, "messages", typ3, val3),
+        )
+
+        conn.commit()
+        conn.close()
+
+    def test_load_past_conversations_empty_db(self) -> None:
+        convs = load_past_conversations(self.db_path)
+        self.assertEqual(convs, {})
+
+    def test_load_past_conversations_with_data(self) -> None:
+        self._seed_db()
+        convs = load_past_conversations(self.db_path)
+        self.assertEqual(len(convs), 3)
+        self.assertIn("thread-100", convs)
+        self.assertIn("thread-200", convs)
+        self.assertIn("thread-300", convs)
+        self.assertEqual(len(convs["thread-100"]), 2)
+        self.assertEqual(len(convs["thread-300"]), 3)
+
+    def test_load_past_conversations_exclude_thread(self) -> None:
+        self._seed_db()
+        convs = load_past_conversations(self.db_path, exclude_thread_id="thread-200")
+        self.assertEqual(len(convs), 2)
+        self.assertNotIn("thread-200", convs)
+
+    def test_search_past_conversations_in_db(self) -> None:
+        self._seed_db()
+
+        # Search for FastAPI
+        results = search_past_conversations_in_db("fastapi docker", db_path=self.db_path)
+        self.assertTrue(len(results) >= 1)
+        self.assertEqual(results[0]["thread_id"], "thread-100")
+        self.assertIn("FastAPI", results[0]["snippets"][0])
+
+        # Search for Alembic
+        results_alembic = search_past_conversations_in_db("alembic", db_path=self.db_path)
+        self.assertEqual(len(results_alembic), 1)
+        self.assertEqual(results_alembic[0]["thread_id"], "thread-300")
+
+        # Search with no matching terms
+        results_none = search_past_conversations_in_db("quantum computing", db_path=self.db_path)
+        self.assertEqual(results_none, [])
+
+        # Search with empty query
+        self.assertEqual(search_past_conversations_in_db("", db_path=self.db_path), [])
+
+    def test_search_past_conversations_limit(self) -> None:
+        self._seed_db()
+        # Query that matches multiple threads (e.g. "how to")
+        results = search_past_conversations_in_db("how to", db_path=self.db_path, limit=1)
+        self.assertEqual(len(results), 1)
+
+    def test_format_past_conversations_context(self) -> None:
+        # Empty results formatting
+        empty_formatted = format_past_conversations_context([])
+        self.assertIn("No relevant past conversations found", empty_formatted)
+
+        # Populated results formatting
+        sample_results = [
+            {
+                "thread_id": "thread-12345678",
+                "score": 3,
+                "snippets": ["[User]: How to configure CORS?", "[Assistant]: Use CORSMiddleware."],
+                "total_messages": 2,
+            }
+        ]
+        formatted = format_past_conversations_context(sample_results)
+        self.assertIn("Session #1 (thread-1)", formatted)
+        self.assertIn("[User]: How to configure CORS?", formatted)
+        self.assertIn("[Assistant]: Use CORSMiddleware.", formatted)
+
+    async def test_search_past_conversations_tool(self) -> None:
+        self._seed_db()
+        set_active_thread_id("thread-100")
+
+        with patch("ollama_agent.agent.episodic_memory.HISTORY_DB_PATH", self.db_path):
+            output = await search_past_conversations.ainvoke({"query": "React Vite"})
+            self.assertIn("react", output.lower())
+            self.assertIn("thread-2", output)
+
+            # Excluded active thread should not appear
+            output_active = await search_past_conversations.ainvoke({"query": "FastAPI"})
+            self.assertIn("No relevant past conversations found", output_active)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interfaces_commands.py
+++ b/tests/test_interfaces_commands.py
@@ -236,6 +236,10 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
         await safe_call(handlers["/session"].handler, ["new"])
         await safe_call(handlers["/session"].handler, ["resume", "session-1234"])
 
+        with patch("ollama_agent.interfaces.dispatch.search_sessions") as mock_search_sess:
+            handlers["/session"].handler(["search", "my-query"])
+            mock_search_sess.assert_called_once()
+
         with patch("ollama_agent.interfaces.dispatch.delete_session") as mock_del_sess:
             handlers["/session"].handler(["delete", "session-1234"])
             mock_del_sess.assert_called_once_with(console, "session-1234")
@@ -255,6 +259,14 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
             handled = handle_cli_commands(args, settings)
             self.assertTrue(handled)
             mock_list.assert_called_once()
+
+    def test_handle_cli_commands_session_search(self) -> None:
+        args = argparse.Namespace(command="session-search", query="fastapi", prompt=None, yolo=False, rag=None)
+        settings = Settings()
+        with patch("ollama_agent.interfaces.dispatch.search_sessions") as mock_search:
+            handled = handle_cli_commands(args, settings)
+            self.assertTrue(handled)
+            mock_search.assert_called_once()
 
     def test_handle_cli_commands_session_delete(self) -> None:
         args = argparse.Namespace(command="session-delete", session_id="session-123", prompt=None, yolo=False, rag=None)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -18,6 +18,7 @@ from ollama_agent.interfaces.session_commands import (
     new_session,
     resolve_session_id,
     resume_session,
+    search_sessions,
 )
 
 
@@ -166,6 +167,18 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(res["success"])
         out = console.export_text()
         self.assertIn("Not enough messages in session to compact", out)
+
+    def test_search_sessions(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+
+        # Empty query
+        res_empty = search_sessions(console, "", db_path=self.db_path)
+        self.assertEqual(res_empty, [])
+        self.assertIn("Please provide a search query", console.export_text())
+
+        # No database
+        res_nodb = search_sessions(console, "python", db_path=self.db_path)
+        self.assertEqual(res_nodb, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR implements **Episodic Memory** support in `ollama-agent` based on the DeepAgents memory specification.

### Highlights
- **Episodic Memory Engine** (`ollama_agent/agent/episodic_memory.py`):
  - Directly parses and deserializes past conversation messages from SQLite (`~/.ollama-agent/history.db`) using `JsonPlusSerializer`.
  - Performs keyword matching across user inputs and assistant solutions, calculating relevance scores.
  - Automatically excludes the current active conversation thread from results.
- **Builtin Agent Tool** (`search_past_conversations`):
  - Registered in `BUILTIN_TOOLS` so the agent can autonomously recall previous solutions, commands, and decisions across past sessions.
- **User Discovery (CLI & REPL)**:
  - **REPL**: `/session search <query>` renders matching sessions and snippets in a Rich table.
  - **CLI**: `ollama-agent session-search <query>`.
- **Documentation**:
  - Updated `README.md`, `docs/skills_tasks_memory.md`, and `docs/cli_repl.md`.
- **Testing**:
  - Added comprehensive test suites in `tests/test_episodic_memory.py` and updated `tests/test_sessions.py` and `tests/test_interfaces_commands.py`.

### Verification
```bash
.venv/bin/python -m unittest discover -s tests
```
Result: All 33 test suites pass cleanly.