### PR TITLE
feat: dynamic model sampling parameter resolution and /params command

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The REPL provides built-in slash commands for managing models, sessions, tasks, 
 | :--- | :--- | :--- |
 | `/help` | `/help` | Display the interactive help panel with command categories. |
 | `/model` | `/model [list \| set <model>]` | List available Ollama models (with tool support indicators) or switch the active model for the current session. |
+| `/params` | `/params [list \| set <parameter> <value>]` | Inspect active sampling parameters and resolution sources, or dynamically update parameter values for the active session. |
 | `/session` | `/session [list \| search <query> \| resume <id> \| new \| export [path] \| delete <id>]` | Manage persistent chat sessions. Search past conversations, resume previous threads, export to Markdown, or delete history. |
 | `/compact` | `/compact` (alias: `/compress`) | Manually compact conversation history into a structured summary to reclaim context window tokens. |
 | `/task` | `/task [list \| create <id> \| run <id> [-y] \| delete <id>]` | Manage saved prompt tasks. Opens interactive modal dialogs for task creation. |
@@ -626,9 +627,15 @@ On initial launch, Ollama Agent generates its configuration directory at `~/.oll
 model:
   name: gemma4:26b
   base_url: http://localhost:11434
-  temperature: 0.0
   context_window: 10000
   reasoning_effort: medium
+  # Optional sampling parameter overrides (omitted by default to resolve dynamically):
+  # temperature: 0.8
+  # top_p: 0.9
+  # top_k: 40
+  # min_p: 0.0
+  # presence_penalty: 0.0
+  # repeat_penalty: 1.1
 runtime:
   allow_traversal: false
   builtin_tool_timeout: 30
@@ -656,7 +663,12 @@ subagents: []
 | :--- | :--- | :--- | :--- |
 | `model.name` | `str` | `gemma4:26b` | Default Ollama model name (must support tool calling). |
 | `model.base_url` | `str` | `http://localhost:11434` | Ollama native API endpoint. |
-| `model.temperature` | `float` | `0.0` | Sampling temperature for model responses. |
+| `model.temperature` | `float` | *(dynamic)* | Optional temperature override (0.8 engine default if unset in Modelfile). |
+| `model.top_p` | `float` | *(dynamic)* | Optional nucleus sampling threshold override (0.9 engine default if unset). |
+| `model.top_k` | `int` | *(dynamic)* | Optional top-k candidates limit override (40 engine default if unset). |
+| `model.min_p` | `float` | *(dynamic)* | Optional minimum probability threshold override (0.0 default if unset). |
+| `model.presence_penalty` | `float` | *(dynamic)* | Optional presence penalty override (0.0 default if unset). |
+| `model.repeat_penalty` | `float` | *(dynamic)* | Optional repetition penalty override (1.1 engine default; alias: `repetition_penalty`). |
 | `model.context_window` | `int` | `10000` | Fallback context window token limit (`num_ctx`). |
 | `model.reasoning_effort` | `str` | `medium` | Default reasoning effort (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`). |
 | `runtime.allow_traversal` | `bool` | `false` | If true, permits filesystem operations outside project working directory. |
@@ -674,6 +686,34 @@ subagents: []
 | `mentions.max_files` | `int` | `100` | Maximum number of files processed during directory mentions. |
 | `mentions.max_total_size` | `int` | `10485760` | Maximum total context size for prompt attachments (10 MB). |
 | `mentions.max_completions` | `int` | `200` | Maximum autocompletion candidates for `@-mentions`. |
+
+---
+
+### Model Parameter Resolution Hierarchy
+
+Sampling parameters (`temperature`, `top_p`, `top_k`, `min_p`, `presence_penalty`, `repeat_penalty`) are resolved dynamically at startup and on model switches following a strict precedence hierarchy:
+
+```mermaid
+flowchart TD
+    A[Start Parameter Resolution] --> B{Defined in settings.yaml?}
+    B -- Yes --> C[Use User Configured Value]
+    B -- No --> D{Declared in Modelfile / Metadata?}
+    D -- Yes --> E[Use Modelfile Recommended Value]
+    D -- No --> F[Use Ollama Engine Default]
+```
+
+1. **User Settings (`settings.yaml`)**: If explicitly specified in configuration, the user's value takes precedence.
+2. **Modelfile / Model Metadata**: If omitted in configuration, the agent inspects the model's metadata (`PARAMETER <name> <value>`) for model-specific recommendations.
+3. **Ollama Engine Defaults**: If not specified in the Modelfile, official Ollama engine defaults are applied:
+   - `temperature`: `0.8`
+   - `top_p`: `0.9`
+   - `top_k`: `40`
+   - `min_p`: `0.0`
+   - `presence_penalty`: `0.0`
+   - `repeat_penalty`: `1.1`
+
+> [!TIP]
+> You can inspect active parameters at any time using `/params` (or `/params list`), and dynamically override parameters for the active session using `/params set <parameter> <value>` (e.g. `/params set temperature 0.7`).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,9 +16,15 @@
 model:
   name: "gemma4:26b"                     # Default Ollama model tag (must support tools)
   base_url: "http://localhost:11434"     # Ollama API server endpoint
-  temperature: 0.0                       # Sampling temperature (0.0 for deterministic outputs)
   context_window: 10000                  # Context window size in tokens (num_ctx)
   reasoning_effort: "medium"             # Reasoning effort: low, medium, high, xhigh, disabled, hide, enabled
+  # Optional sampling parameter overrides (omitted by default to resolve dynamically):
+  # temperature: 0.8                     # Sampling temperature (higher = creative, lower = deterministic)
+  # top_p: 0.9                           # Nucleus sampling probability mass threshold
+  # top_k: 40                            # Limits token selection pool to top K candidates
+  # min_p: 0.0                           # Minimum probability threshold relative to most likely token
+  # presence_penalty: 0.0                # Penalizes tokens if already present in text
+  # repeat_penalty: 1.1                  # Penalizes token repetitions (alias: repetition_penalty)
 
 # Agent Runtime Behavior & Security Policies
 runtime:
@@ -74,7 +80,12 @@ subagents:
 | :--- | :--- | :--- | :--- |
 | `model.name` | `str` | `gemma4:26b` | Default Ollama model name (must support tool calling). |
 | `model.base_url` | `str` | `http://localhost:11434` | Ollama native API endpoint. |
-| `model.temperature` | `float` | `0.0` | Sampling temperature for model responses. |
+| `model.temperature` | `float` | *(dynamic)* | Optional temperature override (0.8 engine default if unset in Modelfile). |
+| `model.top_p` | `float` | *(dynamic)* | Optional nucleus sampling threshold override (0.9 engine default if unset). |
+| `model.top_k` | `int` | *(dynamic)* | Optional top-k candidates limit override (40 engine default if unset). |
+| `model.min_p` | `float` | *(dynamic)* | Optional minimum probability threshold override (0.0 default if unset). |
+| `model.presence_penalty` | `float` | *(dynamic)* | Optional presence penalty override (0.0 default if unset). |
+| `model.repeat_penalty` | `float` | *(dynamic)* | Optional repetition penalty override (1.1 engine default; alias: `repetition_penalty`). |
 | `model.context_window` | `int` | `10000` | Fallback context window token limit (`num_ctx`). |
 | `model.reasoning_effort` | `str` | `medium` | Default reasoning effort (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`). |
 | `runtime.allow_traversal` | `bool` | `false` | If true, permits filesystem operations outside project working directory. |
@@ -96,6 +107,34 @@ subagents:
 | `langsmith.tracing` | `str` | `""` | Enable tracing (`"true"` / `"false"`). |
 | `langsmith.project` | `str` | `""` | LangSmith project name for traces. |
 | `langsmith.endpoint` | `str` | `""` | API endpoint for LangSmith telemetry. |
+
+---
+
+## Model Sampling Parameters Resolution Hierarchy
+
+Sampling parameters (`temperature`, `top_p`, `top_k`, `min_p`, `presence_penalty`, `repeat_penalty`) are resolved dynamically at startup and on model switches following a strict precedence hierarchy:
+
+```mermaid
+flowchart TD
+    A[Start Parameter Resolution] --> B{Defined in settings.yaml?}
+    B -- Yes --> C[Use User Configured Value]
+    B -- No --> D{Declared in Modelfile / Metadata?}
+    D -- Yes --> E[Use Modelfile Recommended Value]
+    D -- No --> F[Use Ollama Engine Default]
+```
+
+1. **User Settings (`settings.yaml`)**: If explicitly specified in configuration, the user's value takes precedence.
+2. **Modelfile / Model Metadata**: If omitted in configuration, the agent inspects the model's metadata (`PARAMETER <name> <value>`) for model-specific recommendations.
+3. **Ollama Engine Defaults**: If not specified in the Modelfile, official Ollama engine defaults are applied:
+   - `temperature`: `0.8`
+   - `top_p`: `0.9`
+   - `top_k`: `40`
+   - `min_p`: `0.0`
+   - `presence_penalty`: `0.0`
+   - `repeat_penalty`: `1.1`
+
+> [!TIP]
+> You can inspect active parameters at any time using `/params` (or `/params list`), and dynamically override parameters for the active session using `/params set <parameter> <value>` (e.g. `/params set temperature 0.7`).
 
 ---
 

--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -83,6 +83,7 @@ class AgentRuntime:
     yolo_mode: bool = field(default=False)
     auto_approved_tools: set[str] = field(default_factory=set)
     last_context_tokens: int = field(default=0, init=False)
+    effective_model_params: dict[str, tuple[Any, str]] = field(default_factory=dict, init=False)
     graph: Any = field(default=None, init=False, repr=False)
     _backend: Any = field(default=None, init=False, repr=False)
     _summarization_mw: Any = field(default=None, init=False, repr=False)
@@ -143,8 +144,14 @@ class AgentRuntime:
             context_window=ms.context_window,
             reasoning_effort=validate_reasoning_effort(ms.reasoning_effort),
             temperature=ms.temperature,
+            top_p=ms.top_p,
+            top_k=ms.top_k,
+            min_p=ms.min_p,
+            presence_penalty=ms.presence_penalty,
+            repeat_penalty=ms.repeat_penalty,
             warn_callback=_log.warning,
         )
+        self.effective_model_params = getattr(model, "effective_params", {})
 
         # Backend: CWD for shell + APP_DIR for agent files (memory, etc.)
         timeout = int(get_tool_timeout())

--- a/ollama_agent/agent/subagents.py
+++ b/ollama_agent/agent/subagents.py
@@ -54,6 +54,12 @@ async def _build_spec(
         base_url=model_settings.base_url,
         context_window=num_ctx,
         reasoning_effort=validate_reasoning_effort(model_settings.reasoning_effort),
+        temperature=model_settings.temperature,
+        top_p=model_settings.top_p,
+        top_k=model_settings.top_k,
+        min_p=model_settings.min_p,
+        presence_penalty=model_settings.presence_penalty,
+        repeat_penalty=model_settings.repeat_penalty,
     )
 
     spec["skills"] = ["/skills/"]

--- a/ollama_agent/core/__init__.py
+++ b/ollama_agent/core/__init__.py
@@ -14,12 +14,15 @@ from .common import (
 from .models import (
     ModelCapabilityError,
     ModelContextWindowError,
+    OLLAMA_PARAM_DEFAULTS,
+    OllamaChatModel,
     create_ollama_chat_model,
     ensure_model_supports_tools,
     get_model_capabilities,
     model_supports_tools,
     model_supports_thinking,
     resolve_context_window,
+    resolve_model_parameters,
     resolve_ollama_reasoning,
     validate_reasoning_effort,
 )
@@ -40,12 +43,15 @@ __all__ = [
     # Models
     "ModelCapabilityError",
     "ModelContextWindowError",
+    "OLLAMA_PARAM_DEFAULTS",
+    "OllamaChatModel",
     "create_ollama_chat_model",
     "ensure_model_supports_tools",
     "get_model_capabilities",
     "model_supports_tools",
     "model_supports_thinking",
     "resolve_context_window",
+    "resolve_model_parameters",
     "resolve_ollama_reasoning",
     "validate_reasoning_effort",
     # Utils

--- a/ollama_agent/core/models.py
+++ b/ollama_agent/core/models.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, cast
 
 import ollama
 from langchain_ollama import ChatOllama
+from pydantic import Field
 
 from .common import (
     ALLOWED_REASONING_EFFORTS,
@@ -141,13 +142,113 @@ async def resolve_ollama_reasoning(
     return effort != "disabled"
 
 
+OLLAMA_PARAM_DEFAULTS: dict[str, Any] = {
+    "temperature": 0.8,
+    "top_p": 0.9,
+    "top_k": 40,
+    "min_p": 0.0,
+    "presence_penalty": 0.0,
+    "repeat_penalty": 1.1,
+}
+
+
+def _parse_modelfile_param(text: str | None, param_name: str) -> str | None:
+    if not text:
+        return None
+    pattern = rf"^\s*(?:PARAMETER\s+)?{re.escape(param_name)}\s+([^\s\n]+)"
+    match = re.search(pattern, text, re.IGNORECASE | re.MULTILINE)
+    return match.group(1) if match else None
+
+
+async def resolve_model_parameters(
+    model: str,
+    base_url: str,
+    *,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    top_k: int | None = None,
+    min_p: float | None = None,
+    presence_penalty: float | None = None,
+    repeat_penalty: float | None = None,
+) -> dict[str, tuple[Any, str]]:
+    """Resolve model sampling parameters with precedence: User > Modelfile > Ollama Default."""
+    user_inputs: dict[str, Any] = {
+        "temperature": temperature,
+        "top_p": top_p,
+        "top_k": top_k,
+        "min_p": min_p,
+        "presence_penalty": presence_penalty,
+        "repeat_penalty": repeat_penalty,
+    }
+
+    response = await _show_model(model, base_url)
+    meta_sources = [
+        getattr(response, "parameters", None),
+        getattr(response, "modelfile", None),
+    ]
+
+    resolved: dict[str, tuple[Any, str]] = {}
+
+    for param, user_val in user_inputs.items():
+        is_int = param == "top_k"
+        if user_val is not None:
+            resolved[param] = (int(user_val) if is_int else float(user_val), "user")
+            continue
+
+        found_val: Any = None
+        for text in meta_sources:
+            raw = _parse_modelfile_param(text, param)
+            if raw is None and param == "repeat_penalty":
+                raw = _parse_modelfile_param(text, "repetition_penalty")
+            if raw is not None:
+                try:
+                    found_val = int(raw) if is_int else float(raw)
+                    break
+                except ValueError:
+                    pass
+
+        if found_val is not None:
+            resolved[param] = (found_val, "modelfile")
+        else:
+            resolved[param] = (OLLAMA_PARAM_DEFAULTS[param], "default")
+
+    return resolved
+
+
+class OllamaChatModel(ChatOllama):
+    """ChatOllama model with support for extended Ollama options and parameter tracking."""
+
+    min_p: float | None = None
+    presence_penalty: float | None = None
+    effective_params: dict[str, tuple[Any, str]] = Field(default_factory=dict)
+
+    def _chat_params(
+        self,
+        messages: list[Any],
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        params = super()._chat_params(messages, stop=stop, **kwargs)
+        options = params.setdefault("options", {})
+        if self.min_p is not None:
+            options["min_p"] = self.min_p
+        if self.presence_penalty is not None:
+            options["presence_penalty"] = self.presence_penalty
+        return params
+
+
 async def create_ollama_chat_model(
     *,
     model: str,
     base_url: str,
     context_window: int | None,
     reasoning_effort: ReasoningEffortValue,
-    temperature: float = 0,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    top_k: int | None = None,
+    min_p: float | None = None,
+    presence_penalty: float | None = None,
+    repeat_penalty: float | None = None,
     warn_callback: Callable[[str], None] = lambda _: None,
 ) -> ChatOllama:
     """Create a native ChatOllama model with resolved runtime settings."""
@@ -156,17 +257,33 @@ async def create_ollama_chat_model(
         model, reasoning_effort, host, warn_callback
     )
     num_ctx = await resolve_context_window(model, context_window, host)
+    resolved_params = await resolve_model_parameters(
+        model,
+        host,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        min_p=min_p,
+        presence_penalty=presence_penalty,
+        repeat_penalty=repeat_penalty,
+    )
 
     kwargs: dict[str, Any] = {
         "base_url": host,
         "model": model,
         "num_ctx": num_ctx,
-        "temperature": temperature,
+        "temperature": resolved_params["temperature"][0],
+        "top_p": resolved_params["top_p"][0],
+        "top_k": resolved_params["top_k"][0],
+        "min_p": resolved_params["min_p"][0],
+        "presence_penalty": resolved_params["presence_penalty"][0],
+        "repeat_penalty": resolved_params["repeat_penalty"][0],
         "profile": {"max_input_tokens": num_ctx},
+        "effective_params": resolved_params,
     }
     if reasoning is not None:
         kwargs["reasoning"] = reasoning
-    return ChatOllama(**kwargs)
+    return OllamaChatModel(**kwargs)
 
 
 def validate_reasoning_effort(effort: str) -> ReasoningEffortValue:

--- a/ollama_agent/interfaces/dispatch.py
+++ b/ollama_agent/interfaces/dispatch.py
@@ -25,7 +25,7 @@ from ..rag import (
 )
 from ..skills import SkillError, SkillsContext, create_skill, delete_skill, list_skills, show_skill
 from ..tasks.commands import CLIContext, TaskError, create_task, delete_task, list_tasks, run_task
-from .model_commands import list_models
+from .model_commands import list_models, set_model_param, show_model_params
 from .session_commands import (
     compact_session,
     delete_session,
@@ -154,6 +154,7 @@ def build_repl_handlers(
     handle_session_resume: Callable[[str], Awaitable[None]] | None = None,
     handle_session_export: Callable[[list[str]], Awaitable[None]] | None = None,
     handle_compact: Callable[[list[str]], Awaitable[None]] | None = None,
+    get_runtime: Callable[[], Any] | None = None,
 ) -> dict[str, REPLCommand]:
     """Build the REPL command registry for unified slash commands."""
 
@@ -165,6 +166,26 @@ def build_repl_handlers(
         if len(args) == 1 and args[0] != "list":
             return switch_model(args[0])
         console.print("[red]Usage: /model [list | set <model>][/red]")
+        return None
+
+    def handle_params(args: list[str]) -> object:
+        if not args or args[0] == "list":
+            if get_runtime is not None:
+                return show_model_params(console, get_runtime())
+            return None
+        if args[0] == "set":
+            if len(args) < 3:
+                console.print(
+                    "[red]Usage: /params set <parameter> <value>[/red]\n"
+                    "[dim]Example: /params set temperature 0.7[/dim]"
+                )
+                return None
+            if get_runtime is not None:
+                return set_model_param(
+                    console, args[1], args[2], runtime=get_runtime()
+                )
+            return None
+        console.print("[red]Usage: /params [list | set <parameter> <value>][/red]")
         return None
 
     def handle_task(args: list[str]) -> object:
@@ -318,6 +339,12 @@ def build_repl_handlers(
             "Model Management",
             "/model [list | set <model>]",
             handle_model,
+        ),
+        "/params": REPLCommand(
+            "Manage model sampling parameters (list, set)",
+            "Model Management",
+            "/params [list | set <parameter> <value>]",
+            handle_params,
         ),
         "/task": REPLCommand(
             "Manage saved tasks (list, create, run, delete)",

--- a/ollama_agent/interfaces/model_commands.py
+++ b/ollama_agent/interfaces/model_commands.py
@@ -6,10 +6,23 @@ import asyncio
 from typing import Any
 
 import ollama
+from rich import box
 from rich.console import Console
+from rich.table import Table
 
 from ..agent import AgentRuntime
 from ..core import ModelCapabilityError, model_supports_tools
+from ..settings import save_settings
+
+VALID_SAMPLING_PARAMS: dict[str, type] = {
+    "temperature": float,
+    "top_p": float,
+    "top_k": int,
+    "min_p": float,
+    "presence_penalty": float,
+    "repeat_penalty": float,
+    "repetition_penalty": float,
+}
 
 
 async def _list_models(base_url: str) -> list[Any]:
@@ -106,4 +119,76 @@ async def set_model(
     except (ollama.ResponseError, OSError) as exc:
         console.print(f"[red]Failed to switch to model '{model_name}': {exc}[/red]")
         return current
+
+
+def show_model_params(console: Console, runtime: AgentRuntime) -> None:
+    """Print the active model parameters and their resolution sources."""
+    model_name = runtime.settings.model.name
+    params = getattr(runtime, "effective_model_params", {})
+    if not params:
+        console.print(
+            f"[yellow]No active parameter data for model '{model_name}'.[/yellow]"
+        )
+        return
+
+    table = Table(
+        title=f"Active Model Parameters: [bold cyan]{model_name}[/bold cyan]",
+        box=box.ROUNDED,
+        header_style="bold magenta",
+    )
+    table.add_column("Parameter", style="cyan")
+    table.add_column("Effective Value", justify="right", style="green")
+    table.add_column("Resolved From", justify="center")
+
+    source_labels = {
+        "user": "[bold yellow]User Config (settings.yaml)[/bold yellow]",
+        "modelfile": "[bold cyan]Modelfile / Metadata[/bold cyan]",
+        "default": "[dim]Ollama Default[/dim]",
+    }
+
+    for name, (val, source) in params.items():
+        src_label = source_labels.get(source, source)
+        table.add_row(name, str(val), src_label)
+
+    console.print(table)
+
+
+async def set_model_param(
+    console: Console,
+    param_name: str,
+    value_str: str,
+    *,
+    runtime: AgentRuntime,
+) -> None:
+    """Set a model sampling parameter for the active session and save to settings."""
+    norm_name = param_name.lower().strip()
+    if norm_name == "repetition_penalty":
+        norm_name = "repeat_penalty"
+
+    if norm_name not in VALID_SAMPLING_PARAMS:
+        valid_list = ", ".join(
+            sorted(p for p in VALID_SAMPLING_PARAMS if p != "repetition_penalty")
+        )
+        console.print(
+            f"[red]Unknown parameter '{param_name}'. Valid parameters: {valid_list}[/red]"
+        )
+        return
+
+    expected_type = VALID_SAMPLING_PARAMS[norm_name]
+    try:
+        val = expected_type(value_str)
+    except ValueError:
+        type_name = "integer" if expected_type is int else "float"
+        console.print(
+            f"[red]Invalid value '{value_str}' for '{norm_name}'. Expected {type_name}.[/red]"
+        )
+        return
+
+    setattr(runtime.settings.model, norm_name, val)
+    await asyncio.to_thread(save_settings, runtime.settings)
+    await runtime.reload()
+    console.print(
+        f"[green]✓ Set [cyan]{norm_name}[/cyan] to [cyan]{val}[/cyan][/green]\n"
+        "[dim]Model reloaded with updated parameters.[/dim]"
+    )
 

--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -60,6 +60,7 @@ _AT_MENTION_RE = re.compile(
 
 _ROOT_COMMANDS: list[tuple[str, str]] = [
     ("/model", "Manage models (list, set)"),
+    ("/params", "Manage model sampling parameters (list, set)"),
     ("/session", "Manage chat sessions (list, search, resume, new, export, delete)"),
     ("/compact", "Compact conversation history into a summary"),
     ("/task", "Manage saved tasks (list, create, run, delete)"),
@@ -76,6 +77,10 @@ _SUBCOMMANDS: dict[str, list[tuple[str, str]]] = {
     "/model": [
         ("list", "List available Ollama models"),
         ("set", "Switch to a different model"),
+    ],
+    "/params": [
+        ("list", "Show active model parameters and resolution sources"),
+        ("set", "Set a parameter value (e.g. /params set temperature 0.7)"),
     ],
     "/session": [
         ("list", "List all past sessions"),
@@ -815,6 +820,7 @@ class OllamaREPL:
                 handle_session_resume=self._handle_session_resume,
                 handle_session_export=self._handle_session_export,
                 handle_compact=self._handle_compact,
+                get_runtime=lambda: self.runtime,
             )
         return self._commands
 

--- a/ollama_agent/settings/config.py
+++ b/ollama_agent/settings/config.py
@@ -73,7 +73,12 @@ def _default_rag_policy() -> str:
 class ModelSettings:
     name: str = "gemma4:26b"
     base_url: str = "http://localhost:11434"
-    temperature: float = 0.0
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    min_p: float | None = None
+    presence_penalty: float | None = None
+    repeat_penalty: float | None = None
     context_window: int = 10000
     reasoning_effort: str = "medium"
 
@@ -164,6 +169,7 @@ class Settings:
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
+        d["model"] = {k: v for k, v in d["model"].items() if v is not None}
         ls = d.get("langsmith", {})
         if ls and not any(ls.values()):
             d.pop("langsmith", None)
@@ -189,8 +195,11 @@ class Settings:
 def _dataclass_from_dict(cls: type[Any], raw: dict[str, Any] | None) -> Any:
     if raw is None:
         return cls()
+    data = dict(raw)
+    if "repetition_penalty" in data and "repeat_penalty" not in data:
+        data["repeat_penalty"] = data.pop("repetition_penalty")
     valid = {f.name for f in fields(cls)}
-    return cls(**{k: v for k, v in raw.items() if k in valid})
+    return cls(**{k: v for k, v in data.items() if k in valid})
 
 
 def _subagents_from_list(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,13 +44,37 @@ class TestConfigManagement(unittest.TestCase):
         s = Settings()
         self.assertEqual(s.model.name, "gemma4:26b")
         self.assertEqual(s.model.context_window, 10000)
+        self.assertIsNone(s.model.temperature)
+        self.assertIsNone(s.model.top_p)
+        self.assertIsNone(s.model.top_k)
+        self.assertIsNone(s.model.min_p)
+        self.assertIsNone(s.model.presence_penalty)
+        self.assertIsNone(s.model.repeat_penalty)
         self.assertEqual(s.runtime.builtin_tool_timeout, 30)
         self.assertEqual(s.mentions.max_files, 100)
         self.assertEqual(s.rag.default_top_k, 5)
 
+        # Default model dict should not include unset sampling parameters
+        model_dict = s.to_dict()["model"]
+        self.assertNotIn("temperature", model_dict)
+        self.assertNotIn("top_p", model_dict)
+        self.assertNotIn("top_k", model_dict)
+        self.assertNotIn("min_p", model_dict)
+        self.assertNotIn("presence_penalty", model_dict)
+        self.assertNotIn("repeat_penalty", model_dict)
+
     def test_settings_serialization_cycle(self) -> None:
         original = Settings(
-            model=ModelSettings(name="llama3.3:70b", reasoning_effort="high"),
+            model=ModelSettings(
+                name="llama3.3:70b",
+                reasoning_effort="high",
+                temperature=0.7,
+                top_p=0.95,
+                top_k=50,
+                min_p=0.05,
+                presence_penalty=0.5,
+                repeat_penalty=1.2,
+            ),
             runtime=RuntimeSettings(allow_traversal=True, builtin_tool_timeout=60),
             subagents=[
                 SubAgentSettings(
@@ -67,12 +91,28 @@ class TestConfigManagement(unittest.TestCase):
         loaded = load_settings(self.settings_file)
         self.assertEqual(loaded.model.name, "llama3.3:70b")
         self.assertEqual(loaded.model.reasoning_effort, "high")
+        self.assertEqual(loaded.model.temperature, 0.7)
+        self.assertEqual(loaded.model.top_p, 0.95)
+        self.assertEqual(loaded.model.top_k, 50)
+        self.assertEqual(loaded.model.min_p, 0.05)
+        self.assertEqual(loaded.model.presence_penalty, 0.5)
+        self.assertEqual(loaded.model.repeat_penalty, 1.2)
         self.assertTrue(loaded.runtime.allow_traversal)
         self.assertEqual(loaded.runtime.builtin_tool_timeout, 60)
         self.assertEqual(len(loaded.subagents), 1)
         self.assertEqual(loaded.subagents[0].name, "coder")
         self.assertEqual(len(loaded.subagents[0].mcp_servers), 1)
         self.assertEqual(loaded.subagents[0].mcp_servers[0].name, "git")
+
+    def test_model_repetition_penalty_alias(self) -> None:
+        raw = {
+            "model": {
+                "name": "llama3.2:3b",
+                "repetition_penalty": 1.3,
+            }
+        }
+        s = Settings.from_dict(raw)
+        self.assertEqual(s.model.repeat_penalty, 1.3)
 
     def test_setup_environment_injects_langsmith_variables(self) -> None:
         with patch.dict(os.environ, {}, clear=False):

--- a/tests/test_interfaces_commands.py
+++ b/tests/test_interfaces_commands.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from ollama_agent.core.models import ModelCapabilityError
 from ollama_agent.interfaces.cli import handle_cli_commands
 from ollama_agent.interfaces.dispatch import build_repl_handlers, render_repl_help, safe_call
-from ollama_agent.interfaces.model_commands import list_models, set_model
+from ollama_agent.interfaces.model_commands import list_models, set_model, set_model_param, show_model_params
 from ollama_agent.interfaces.session_commands import new_session
 from ollama_agent.settings.config import Settings
 from ollama_agent.skills.commands import SkillError
@@ -114,6 +114,102 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(res, "qwen3:32b")
             runtime.set_model.assert_awaited_once_with("qwen3:32b")
             self.assertIn("Switched", console.export_text())
+
+    def test_show_model_params(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime = MagicMock()
+        runtime.settings.model.name = "llama3.2:3b"
+        runtime.effective_model_params = {
+            "temperature": (0.7, "user"),
+            "top_p": (0.85, "modelfile"),
+            "top_k": (40, "default"),
+        }
+
+        show_model_params(console, runtime)
+        out = console.export_text()
+        self.assertIn("Active Model Parameters", out)
+        self.assertIn("llama3.2:3b", out)
+        self.assertIn("temperature", out)
+        self.assertIn("0.7", out)
+        self.assertIn("User Config", out)
+        self.assertIn("Modelfile", out)
+        self.assertIn("Ollama Default", out)
+
+    async def test_set_model_param_success(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime = MagicMock()
+        runtime.settings.model.temperature = 0.8
+        runtime.reload = AsyncMock()
+
+        with patch("ollama_agent.interfaces.model_commands.save_settings"):
+            await set_model_param(console, "temperature", "0.5", runtime=runtime)
+            self.assertEqual(runtime.settings.model.temperature, 0.5)
+            runtime.reload.assert_awaited_once()
+            out = console.export_text()
+            self.assertIn("Set", out)
+            self.assertIn("temperature", out)
+            self.assertIn("0.5", out)
+
+    async def test_set_model_param_invalid(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime = MagicMock()
+
+        # Unknown param
+        await set_model_param(console, "invalid_param", "0.5", runtime=runtime)
+        self.assertIn("Unknown parameter", console.export_text())
+
+        # Invalid type
+        console = Console(file=io.StringIO(), record=True)
+        await set_model_param(console, "temperature", "not_a_number", runtime=runtime)
+        self.assertIn("Invalid value", console.export_text())
+
+    def test_params_dispatch(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime = MagicMock()
+        runtime.settings.model.name = "llama3.2:3b"
+        runtime.effective_model_params = {
+            "temperature": (0.8, "default"),
+        }
+
+        handlers = build_repl_handlers(
+            task_ctx=MagicMock(),
+            skills_ctx=MagicMock(),
+            get_rag_ctx=MagicMock(),
+            console=console,
+            current_model=lambda: "llama3.2:3b",
+            base_url=lambda: "http://localhost:11434",
+            switch_model=AsyncMock(),
+            handle_exit=lambda _: None,
+            handle_clear=lambda _: None,
+            handle_new=AsyncMock(),
+            handle_task_create=lambda _: None,
+            handle_skill_create=lambda _: None,
+            handle_yolo=lambda _: None,
+            get_runtime=lambda: runtime,
+        )
+
+        # /params
+        handlers["/params"].callback([])
+        out = console.export_text()
+        self.assertIn("Active Model Parameters", out)
+
+        # /params list
+        console = Console(file=io.StringIO(), record=True)
+        handlers["/params"].callback(["list"])
+        out_list = console.export_text()
+        self.assertIn("Active Model Parameters", out_list)
+
+        # /params set with missing args
+        console = Console(file=io.StringIO(), record=True)
+        handlers["/params"].callback(["set", "temperature"])
+        out_missing = console.export_text()
+        self.assertIn("Usage: /params set", out_missing)
+
+        # /model does not handle params
+        console = Console(file=io.StringIO(), record=True)
+        handlers["/model"].callback(["params"])
+        out_model = console.export_text()
+        self.assertIn("Usage: /model", out_model)
 
     def test_render_repl_help(self) -> None:
         console = Console(file=io.StringIO(), record=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from ollama_agent.core.models import (
     ModelCapabilityError,
     ModelContextWindowError,
+    OLLAMA_PARAM_DEFAULTS,
     _model_context_length,
+    _parse_modelfile_param,
     _parse_num_ctx,
     create_ollama_chat_model,
     ensure_model_supports_tools,
@@ -14,6 +16,7 @@ from ollama_agent.core.models import (
     model_supports_thinking,
     model_supports_tools,
     resolve_context_window,
+    resolve_model_parameters,
     resolve_ollama_reasoning,
     validate_reasoning_effort,
 )
@@ -128,9 +131,92 @@ class TestModelsLogic(unittest.IsolatedAsyncioTestCase):
             base_url="http://localhost:11434",
             context_window=8192,
             reasoning_effort="high",
+            temperature=0.7,
+            top_p=0.95,
+            top_k=50,
+            min_p=0.05,
+            presence_penalty=0.5,
+            repeat_penalty=1.2,
         )
         self.assertIsNotNone(model)
         self.assertEqual(model.model, "gemma4:26b")
+        self.assertEqual(model.temperature, 0.7)
+        self.assertEqual(model.top_p, 0.95)
+        self.assertEqual(model.top_k, 50)
+        self.assertEqual(model.repeat_penalty, 1.2)
+        self.assertEqual(model.min_p, 0.05)
+        self.assertEqual(model.presence_penalty, 0.5)
+
+        params = model._chat_params([])
+        options = params["options"]
+        self.assertEqual(options["temperature"], 0.7)
+        self.assertEqual(options["top_p"], 0.95)
+        self.assertEqual(options["top_k"], 50)
+        self.assertEqual(options["repeat_penalty"], 1.2)
+        self.assertEqual(options["min_p"], 0.05)
+        self.assertEqual(options["presence_penalty"], 0.5)
+
+    def test_parse_modelfile_param(self) -> None:
+        text = "PARAMETER temperature 0.65\nPARAMETER top_p 0.85\nPARAMETER top_k 30\nrepeat_penalty 1.15"
+        self.assertEqual(_parse_modelfile_param(text, "temperature"), "0.65")
+        self.assertEqual(_parse_modelfile_param(text, "top_p"), "0.85")
+        self.assertEqual(_parse_modelfile_param(text, "top_k"), "30")
+        self.assertEqual(_parse_modelfile_param(text, "repeat_penalty"), "1.15")
+        self.assertIsNone(_parse_modelfile_param(text, "min_p"))
+        self.assertIsNone(_parse_modelfile_param(None, "temperature"))
+
+    @patch("ollama_agent.core.models._show_model")
+    async def test_resolve_model_parameters_precedence(self, mock_show: AsyncMock) -> None:
+        mock_show.return_value = MagicMock(
+            parameters="temperature 0.65\ntop_p 0.85\nrepetition_penalty 1.25",
+            modelfile=None,
+        )
+
+        # 1. User overrides temperature; top_p and repeat_penalty resolve from metadata; others from defaults
+        resolved = await resolve_model_parameters(
+            "test-model",
+            "http://localhost:11434",
+            temperature=0.3,
+            top_p=None,
+            top_k=None,
+            min_p=None,
+            presence_penalty=None,
+            repeat_penalty=None,
+        )
+
+        # User value
+        self.assertEqual(resolved["temperature"], (0.3, "user"))
+        # Modelfile values
+        self.assertEqual(resolved["top_p"], (0.85, "modelfile"))
+        self.assertEqual(resolved["repeat_penalty"], (1.25, "modelfile"))
+        # Ollama Default values
+        self.assertEqual(resolved["top_k"], (OLLAMA_PARAM_DEFAULTS["top_k"], "default"))
+        self.assertEqual(resolved["min_p"], (OLLAMA_PARAM_DEFAULTS["min_p"], "default"))
+        self.assertEqual(resolved["presence_penalty"], (OLLAMA_PARAM_DEFAULTS["presence_penalty"], "default"))
+
+    @patch("ollama_agent.core.models._show_model")
+    @patch("ollama_agent.core.models.resolve_context_window", AsyncMock(return_value=4096))
+    @patch("ollama_agent.core.models.resolve_ollama_reasoning", AsyncMock(return_value=None))
+    async def test_create_ollama_chat_model_resolves_defaults(self, mock_show: AsyncMock) -> None:
+        mock_show.return_value = MagicMock(
+            parameters="",
+            modelfile="",
+            capabilities=["tools"],
+        )
+        model = await create_ollama_chat_model(
+            model="default-model",
+            base_url="http://localhost:11434",
+            context_window=4096,
+            reasoning_effort="disabled",
+        )
+        self.assertEqual(model.temperature, 0.8)
+        self.assertEqual(model.top_p, 0.9)
+        self.assertEqual(model.top_k, 40)
+        self.assertEqual(model.min_p, 0.0)
+        self.assertEqual(model.presence_penalty, 0.0)
+        self.assertEqual(model.repeat_penalty, 1.1)
+        self.assertIn("temperature", model.effective_params)
+        self.assertEqual(model.effective_params["temperature"][1], "default")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Dynamic sampling parameter resolution hierarchy: User config (`settings.yaml`) -> Modelfile recommendation (`PARAMETER <name> <value>`) -> Ollama engine defaults (`0.8`, `0.9`, `40`, `0.0`, `0.0`, `1.1`).
- Clean default `settings.yaml` generated at first launch without fixed sampling parameter values.
- Interactive `/params` command with `/params list` (inspect active params and resolution source) and `/params set <param> <value>` (dynamically change params in current session and save to settings).
- Comprehensive test coverage and documentation updates in `README.md` and `docs/configuration.md`.