### PR TITLE
feat: interactive model selection on startup when unconfigured or missing in Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Before running Ollama Agent, ensure the following dependencies are available on 
 
 1. **Python 3.11+**: Ensure Python 3.11 or newer is installed.
 2. **Ollama**: Installed and running locally (or reachable at your configured host).
-3. **Tool-Calling Model**: A local model with tool/function-calling capabilities (e.g. `gemma4:26b`, `qwen2.5:14b`, `llama3.1:8b`). If the selected model lacks tool support, the agent will report an error and exit.
+3. **Tool-Calling Model**: A local model with tool/function-calling capabilities (e.g. `qwen3.8:27b`, `qwen2.5:14b`, `llama3.1:8b`). If the selected model lacks tool support, the agent will report an error and exit. If no model is configured or the configured model is missing, the agent will prompt you to select one interactively from your downloaded Ollama models.
 4. **Embeddings Model (for RAG)**: If using RAG features, download the default embedding model in Ollama:
    ```bash
    ollama pull nomic-embed-text:latest
@@ -293,7 +293,7 @@ flowchart LR
 
 | Flag | Short | Type | Default | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| `--model` | `-m` | `str` | `gemma4:26b` | Specify the Ollama model for this session. |
+| `--model` | `-m` | `str` | `settings.yaml` | Specify the Ollama model for this session (falls back to interactive selection if unconfigured or missing in Ollama). |
 | `--prompt` | `-p` | `str` | `None` | Run in non-interactive mode with the provided prompt. |
 | `--effort` | `-e` | `str` | `medium` | Set reasoning effort level (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`). |
 | `--builtin-tool-timeout` | `-t` | `int` | `30` | Timeout in seconds for tool executions (including shell commands). |
@@ -619,13 +619,13 @@ subagents:
 
 ## Configuration & Customization
 
-On initial launch, Ollama Agent generates its configuration directory at `~/.ollama-agent/` and initializes `settings.yaml`.
+On initial launch, Ollama Agent generates its configuration directory at `~/.ollama-agent/` and initializes `settings.yaml`. If no model is configured or if the configured model is not downloaded in Ollama, the agent interactively prompts you to choose from your locally available Ollama models and saves your choice to `settings.yaml`.
 
 ### Configuration File (`settings.yaml`)
 
 ```yaml
 model:
-  name: gemma4:26b
+  name: qwen3.8:27b
   base_url: http://localhost:11434
   context_window: 10000
   reasoning_effort: medium
@@ -661,7 +661,7 @@ subagents: []
 
 | Section & Key | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `model.name` | `str` | `gemma4:26b` | Default Ollama model name (must support tool calling). |
+| `model.name` | `str` | *(interactive)* | Configured Ollama model name (must support tool calling). Selected interactively if unconfigured or missing. |
 | `model.base_url` | `str` | `http://localhost:11434` | Ollama native API endpoint. |
 | `model.temperature` | `float` | *(dynamic)* | Optional temperature override (0.8 engine default if unset in Modelfile). |
 | `model.top_p` | `float` | *(dynamic)* | Optional nucleus sampling threshold override (0.9 engine default if unset). |

--- a/docs/cli_repl.md
+++ b/docs/cli_repl.md
@@ -46,7 +46,7 @@ ollama-agent --rag project-docs -p "How is authentication configured in this rep
 
 | Flag | Short | Type | Default | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| `--model` | `-m` | `str` | `gemma4:26b` | Specify the Ollama model for this session. |
+| `--model` | `-m` | `str` | `settings.yaml` | Specify the Ollama model for this session (falls back to interactive selection if unconfigured or missing in Ollama). |
 | `--prompt` | `-p` | `str` | `None` | Run in non-interactive mode with the provided prompt. |
 | `--effort` | `-e` | `str` | `medium` | Set reasoning effort level (`low`, `medium`, `high`, `disabled`, `hide`, `enabled`). |
 | `--builtin-tool-timeout` | `-t` | `int` | `30` | Timeout in seconds for tool executions (including shell commands). |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@
 
 # Primary LLM Model Settings
 model:
-  name: "gemma4:26b"                     # Default Ollama model tag (must support tools)
+  name: "qwen3.8:27b"                     # Active Ollama model tag (must support tools)
   base_url: "http://localhost:11434"     # Ollama API server endpoint
   context_window: 10000                  # Context window size in tokens (num_ctx)
   reasoning_effort: "medium"             # Reasoning effort: low, medium, high, xhigh, disabled, hide, enabled
@@ -78,7 +78,7 @@ subagents:
 
 | Section & Key | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `model.name` | `str` | `gemma4:26b` | Default Ollama model name (must support tool calling). |
+| `model.name` | `str` | *(interactive)* | Configured Ollama model name (must support tool calling). Selected interactively if unconfigured or missing. |
 | `model.base_url` | `str` | `http://localhost:11434` | Ollama native API endpoint. |
 | `model.temperature` | `float` | *(dynamic)* | Optional temperature override (0.8 engine default if unset in Modelfile). |
 | `model.top_p` | `float` | *(dynamic)* | Optional nucleus sampling threshold override (0.9 engine default if unset). |

--- a/ollama_agent/interfaces/model_commands.py
+++ b/ollama_agent/interfaces/model_commands.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, Callable
 
 import ollama
 from rich import box
@@ -12,7 +12,7 @@ from rich.table import Table
 
 from ..agent import AgentRuntime
 from ..core import ModelCapabilityError, model_supports_tools
-from ..settings import save_settings
+from ..settings import Settings, save_settings
 
 VALID_SAMPLING_PARAMS: dict[str, type] = {
     "temperature": float,
@@ -23,6 +23,13 @@ VALID_SAMPLING_PARAMS: dict[str, type] = {
     "repeat_penalty": float,
     "repetition_penalty": float,
 }
+
+
+def _list_models_sync(base_url: str) -> list[Any]:
+    """Fetch the list of available Ollama models synchronously."""
+    client = ollama.Client(host=base_url)
+    response = client.list()
+    return list(response.models)
 
 
 async def _list_models(base_url: str) -> list[Any]:
@@ -191,4 +198,90 @@ async def set_model_param(
         f"[green]✓ Set [cyan]{norm_name}[/cyan] to [cyan]{val}[/cyan][/green]\n"
         "[dim]Model reloaded with updated parameters.[/dim]"
     )
+
+
+def ensure_model_configured(
+    settings: Settings,
+    console: Console | None = None,
+    input_func: Callable[[str], str] = input,
+) -> str:
+    """Ensure the configured model is available in Ollama, or prompt the user to choose one."""
+    base_url = settings.model.base_url
+    try:
+        models = _list_models_sync(base_url)
+        available_models = [m for m in models if getattr(m, "model", None)]
+    except Exception as exc:
+        raise ModelCapabilityError(
+            f"Could not connect to Ollama at '{base_url}': {exc}"
+        ) from exc
+
+    if not available_models:
+        raise ModelCapabilityError(
+            f"No models found in Ollama at '{base_url}'. Please pull a model first with 'ollama pull <model>'."
+        )
+
+    model_names = [m.model for m in available_models]
+    configured = settings.model.name.strip()
+    if configured:
+        if configured in model_names:
+            return configured
+        if f"{configured}:latest" in model_names:
+            settings.model.name = f"{configured}:latest"
+            save_settings(settings)
+            return settings.model.name
+
+    out = console if console is not None else Console()
+    if configured:
+        out.print(
+            f"[yellow]Configured model '[bold cyan]{configured}[/bold cyan]' is not available in Ollama.[/yellow]"
+        )
+    else:
+        out.print("[yellow]No model is currently configured in settings.[/yellow]")
+
+    out.print("[bold]Available Ollama models:[/bold]")
+    for i, item in enumerate(available_models, start=1):
+        size_str = (
+            f" ({item.size / (1024**3):.1f} GB)"
+            if getattr(item, "size", None)
+            else ""
+        )
+        out.print(f"  [cyan]{i})[/cyan] [bold]{item.model}[/bold]{size_str}")
+
+    while True:
+        try:
+            choice = input_func(
+                f"Select a model [1-{len(available_models)}]: "
+            ).strip()
+        except (KeyboardInterrupt, EOFError):
+            raise SystemExit(1)
+        if not choice:
+            continue
+        if choice.isdigit():
+            idx = int(choice) - 1
+            if 0 <= idx < len(available_models):
+                selected = available_models[idx].model
+                break
+        else:
+            matched = next(
+                (
+                    m.model
+                    for m in available_models
+                    if m.model == choice or m.model == f"{choice}:latest"
+                ),
+                None,
+            )
+            if matched is not None:
+                selected = matched
+                break
+        out.print(
+            f"[red]Invalid selection '{choice}'. Please enter a number between 1 and {len(available_models)} or a model name.[/red]"
+        )
+
+    settings.model.name = selected
+    save_settings(settings)
+    out.print(
+        f"[green]✓ Selected model '[bold cyan]{selected}[/bold cyan]' saved to configuration.[/green]\n"
+    )
+    return selected
+
 

--- a/ollama_agent/main.py
+++ b/ollama_agent/main.py
@@ -10,6 +10,7 @@ from .agent import AgentRuntime
 from .agent.builtin_tools import set_tool_timeout
 from .core import ModelCapabilityError, ModelContextWindowError
 from .interfaces.cli import create_argument_parser, handle_cli_commands
+from .interfaces.model_commands import ensure_model_configured
 from .interfaces.repl import OllamaREPL
 from .settings import load_settings, reset_config
 
@@ -24,7 +25,6 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 def main() -> None:
     """Main entry point."""
 
-
     parser = create_argument_parser()
     args = parser.parse_args()
 
@@ -32,7 +32,6 @@ def main() -> None:
         for msg in reset_config(args.config_reset):
             print(msg)
         return
-
 
     settings = load_settings()
     settings.setup_environment()
@@ -50,7 +49,14 @@ def main() -> None:
     set_tool_timeout(settings.runtime.builtin_tool_timeout)
 
     try:
-        if handle_cli_commands(args, settings):
+        if args.command:
+            handle_cli_commands(args, settings)
+            return
+
+        ensure_model_configured(settings)
+
+        if args.prompt:
+            handle_cli_commands(args, settings)
             return
 
         runtime = AgentRuntime(settings=settings, yolo_mode=args.yolo)

--- a/ollama_agent/settings/config.py
+++ b/ollama_agent/settings/config.py
@@ -71,7 +71,7 @@ def _default_rag_policy() -> str:
 
 @dataclass(slots=True)
 class ModelSettings:
-    name: str = "gemma4:26b"
+    name: str = ""
     base_url: str = "http://localhost:11434"
     temperature: float | None = None
     top_p: float | None = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,7 +42,7 @@ class TestConfigManagement(unittest.TestCase):
 
     def test_default_settings_instantiation(self) -> None:
         s = Settings()
-        self.assertEqual(s.model.name, "gemma4:26b")
+        self.assertEqual(s.model.name, "")
         self.assertEqual(s.model.context_window, 10000)
         self.assertIsNone(s.model.temperature)
         self.assertIsNone(s.model.top_p)

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -131,11 +131,13 @@ class TestDispatchAndCLI(unittest.TestCase):
         mock_settings = Settings()
         with patch("sys.argv", ["ollama-agent", "-m", "qwen3:32b", "-e", "high", "--builtin-tool-timeout", "40"]), \
              patch("ollama_agent.main.load_settings", return_value=mock_settings), \
+             patch("ollama_agent.main.ensure_model_configured", return_value="qwen3:32b") as mock_ensure, \
              patch("ollama_agent.main.handle_cli_commands", return_value=False), \
              patch("ollama_agent.main.AgentRuntime") as mock_runtime_cls, \
              patch("ollama_agent.main.OllamaREPL") as mock_repl_cls, \
              patch("asyncio.run") as mock_asyncio_run:
             main()
+            mock_ensure.assert_called_once_with(mock_settings)
             self.assertEqual(mock_settings.model.name, "qwen3:32b")
             self.assertEqual(mock_settings.model.reasoning_effort, "high")
             self.assertEqual(mock_settings.runtime.builtin_tool_timeout, 40)
@@ -147,7 +149,7 @@ class TestDispatchAndCLI(unittest.TestCase):
         with patch("sys.argv", ["ollama-agent"]), \
              patch("ollama_agent.main.Console"), \
              patch("ollama_agent.main.load_settings", return_value=Settings()), \
-             patch("ollama_agent.main.handle_cli_commands", side_effect=ModelCapabilityError("Model unsupported")):
+             patch("ollama_agent.main.ensure_model_configured", side_effect=ModelCapabilityError("Model unsupported")):
             with self.assertRaises(SystemExit) as cm:
                 main()
             self.assertEqual(cm.exception.code, 1)

--- a/tests/test_interfaces_commands.py
+++ b/tests/test_interfaces_commands.py
@@ -10,7 +10,13 @@ from rich.console import Console
 from ollama_agent.core.models import ModelCapabilityError
 from ollama_agent.interfaces.cli import handle_cli_commands
 from ollama_agent.interfaces.dispatch import build_repl_handlers, render_repl_help, safe_call
-from ollama_agent.interfaces.model_commands import list_models, set_model, set_model_param, show_model_params
+from ollama_agent.interfaces.model_commands import (
+    ensure_model_configured,
+    list_models,
+    set_model,
+    set_model_param,
+    show_model_params,
+)
 from ollama_agent.interfaces.session_commands import new_session
 from ollama_agent.settings.config import Settings
 from ollama_agent.skills.commands import SkillError
@@ -396,4 +402,105 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
         args = argparse.Namespace(command=None, prompt=None)
         settings = Settings()
         self.assertFalse(handle_cli_commands(args, settings))
+
+    def test_ensure_model_configured_already_available(self) -> None:
+        settings = Settings()
+        settings.model.name = "qwen3:32b"
+        mock_m1 = MagicMock(model="qwen3:32b", size=1024**3 * 10)
+        mock_m2 = MagicMock(model="llama3:8b", size=1024**3 * 5)
+        mock_resp = MagicMock(models=[mock_m1, mock_m2])
+
+        with patch("ollama.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.list.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            res = ensure_model_configured(settings)
+            self.assertEqual(res, "qwen3:32b")
+            self.assertEqual(settings.model.name, "qwen3:32b")
+
+    def test_ensure_model_configured_latest_alias(self) -> None:
+        settings = Settings()
+        settings.model.name = "llama3"
+        mock_m = MagicMock(model="llama3:latest", size=1024**3 * 5)
+        mock_resp = MagicMock(models=[mock_m])
+
+        with patch("ollama.Client") as mock_client_cls, \
+             patch("ollama_agent.interfaces.model_commands.save_settings") as mock_save:
+            mock_client = MagicMock()
+            mock_client.list.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            res = ensure_model_configured(settings)
+            self.assertEqual(res, "llama3:latest")
+            self.assertEqual(settings.model.name, "llama3:latest")
+            mock_save.assert_called_once_with(settings)
+
+    def test_ensure_model_configured_prompt_numeric_selection(self) -> None:
+        settings = Settings()
+        settings.model.name = "qwen3.8:2b"
+        mock_m1 = MagicMock(model="qwen3.8:27b", size=1024**3 * 17)
+        mock_m2 = MagicMock(model="ornith-1.5:9b", size=1024**3 * 6)
+        mock_resp = MagicMock(models=[mock_m1, mock_m2])
+
+        console = Console(file=io.StringIO(), record=True)
+        with patch("ollama.Client") as mock_client_cls, \
+             patch("ollama_agent.interfaces.model_commands.save_settings") as mock_save:
+            mock_client = MagicMock()
+            mock_client.list.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            inputs = iter(["1"])
+            res = ensure_model_configured(settings, console=console, input_func=lambda _: next(inputs))
+            self.assertEqual(res, "qwen3.8:27b")
+            self.assertEqual(settings.model.name, "qwen3.8:27b")
+            mock_save.assert_called_once_with(settings)
+            out = console.export_text()
+            self.assertIn("not available in Ollama", out)
+            self.assertIn("qwen3.8:27b", out)
+
+    def test_ensure_model_configured_prompt_name_selection(self) -> None:
+        settings = Settings()
+        settings.model.name = ""
+        mock_m1 = MagicMock(model="qwen3.8:27b", size=1024**3 * 17)
+        mock_m2 = MagicMock(model="ornith-1.5:9b", size=1024**3 * 6)
+        mock_resp = MagicMock(models=[mock_m1, mock_m2])
+
+        console = Console(file=io.StringIO(), record=True)
+        with patch("ollama.Client") as mock_client_cls, \
+             patch("ollama_agent.interfaces.model_commands.save_settings") as mock_save:
+            mock_client = MagicMock()
+            mock_client.list.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            inputs = iter(["invalid_name", "ornith-1.5:9b"])
+            res = ensure_model_configured(settings, console=console, input_func=lambda _: next(inputs))
+            self.assertEqual(res, "ornith-1.5:9b")
+            self.assertEqual(settings.model.name, "ornith-1.5:9b")
+            mock_save.assert_called_once_with(settings)
+            out = console.export_text()
+            self.assertIn("No model is currently configured", out)
+            self.assertIn("Invalid selection", out)
+
+    def test_ensure_model_configured_no_models_raises(self) -> None:
+        settings = Settings()
+        mock_resp = MagicMock(models=[])
+
+        with patch("ollama.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.list.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            with self.assertRaises(ModelCapabilityError) as cm:
+                ensure_model_configured(settings)
+            self.assertIn("No models found in Ollama", str(cm.exception))
+
+    def test_ensure_model_configured_connection_error_raises(self) -> None:
+        settings = Settings()
+
+        with patch("ollama.Client", side_effect=ConnectionError("Refused")):
+            with self.assertRaises(ModelCapabilityError) as cm:
+                ensure_model_configured(settings)
+            self.assertIn("Could not connect to Ollama", str(cm.exception))
+
 


### PR DESCRIPTION
## Summary
- **Dynamic Model Selection**: On startup, if no model is configured or if the configured model in `settings.yaml` is not downloaded in Ollama, the agent fetches available local models from Ollama, displays a numbered list, and interactively prompts the user to select one.
- **Persistence**: Automatically persists the user's choice to `~/.ollama-agent/settings.yaml` so subsequent executions use that model seamlessly without prompting.
- **Removed Hardcoded Default Model**: Removed `"gemma4:26b"` hardcoded default from `ModelSettings.name` (`name: str = ""`) to avoid assuming a default model not present on the user's system.
- **Unified Dispatch**: Simplified startup control flow in `ollama_agent/main.py` ensuring CLI subcommands execute directly while agent flows (prompt / REPL) validate model availability cleanly.
- **Tests & Docs**: Added unit tests covering all scenarios in `tests/test_interfaces_commands.py` and updated `README.md`, `docs/configuration.md`, and `docs/cli_repl.md`.

## Quality & Standards
- Follows KISS and zero defensive bloat principles.
- Top-level PEP 8 imports.
- Fail fast and loud on connection or model listing errors.
- 33/33 tests passing.