### PR TITLE
feat(repl): add model autocomplete for /model set command

### DIFF
--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+import ollama
 from rich.console import Console
 from rich.text import Text
 
@@ -39,7 +40,7 @@ from ..rag import RAGContext, RAGManager, load_rag_database
 from ..skills import SkillsContext, create_skill
 from ..tasks.commands import CLIContext, TaskError, create_task
 from .dispatch import REPLCommand, build_repl_handlers, safe_call
-from .model_commands import set_model
+from .model_commands import _list_models_sync, set_model
 from .session_commands import (
     compact_session,
     export_session,
@@ -324,6 +325,22 @@ class OllamaAgentApp(App):
         if num_parts == 3:
             sub_cmd = parts[1]
             arg_token = parts[2]
+
+            if root_cmd == "/model" and sub_cmd == "set":
+                try:
+                    models = _list_models_sync(self.repl.runtime.settings.model.base_url)
+                except (ollama.ResponseError, OSError):
+                    return []
+                return [
+                    (
+                        f"{root_cmd} {sub_cmd} {m.model}",
+                        Text.from_markup(
+                            f"[bold #e6edf3]{m.model:<30}[/bold #e6edf3] [dim #8b949e]{f'{(m.size / (1024**3)):.1f}GB' if m.size else ''}[/dim #8b949e]"
+                        ),
+                    )
+                    for m in models
+                    if m.model and m.model.startswith(arg_token)
+                ]
 
             if root_cmd == "/task" and sub_cmd in ("run", "delete"):
                 tasks = self.repl._task_ctx.task_manager.list_all()
@@ -668,6 +685,8 @@ class OllamaAgentApp(App):
             self.update_yolo_ui()
         elif cmd == "/rag" and args and args[0] in ("load", "unload", "delete"):
             await self.repl.runtime.reload()
+        elif cmd == "/model" and args and args[0] == "set":
+            self.query_one(AgentHeader).update_header()
 
     # ── Modal helpers ─────────────────────────────────────────────────────
 

--- a/ollama_agent/settings/prompts/fs_policy_traversal.md
+++ b/ollama_agent/settings/prompts/fs_policy_traversal.md
@@ -1,5 +1,5 @@
 # FILESYSTEM
-- In traversal mode, you have access to the entire host filesystem.
+- You have access to the entire host filesystem.
 - For file tools (`read_file`, `write_file`, `ls`, `grep`), `/` is the host system root (`/etc`, `/home`, etc.).
   - To access project files, use relative paths (e.g., `read_file(file_path="src/main.py")`) or inspect the project with `ls(path=".")`.
   - To discover the absolute project path, run `execute(command="pwd")` (Unix/macOS) or `execute(command="cd")` (Windows).

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -471,6 +471,24 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
                 self.assertFalse(autolist.display)
                 self.assertEqual(autolist.option_count, 0)
 
+            # 7. Level 2: Dynamic Models for /model set
+            mock_m1 = MagicMock(model="llama3.2:latest", size=4 * 1024**3)
+            mock_m2 = MagicMock(model="mistral:latest", size=5 * 1024**3)
+            with patch("ollama_agent.interfaces.repl._list_models_sync", return_value=[mock_m1, mock_m2]):
+                app.update_autocomplete("/model set ")
+                self.assertTrue(autolist.display)
+                self.assertEqual(autolist.option_count, 2)
+
+                app.update_autocomplete("/model set llam")
+                self.assertEqual(autolist.option_count, 1)
+                app.accept_completion(0)
+                self.assertEqual(inp.text, "/model set llama3.2:latest ")
+
+            with patch("ollama_agent.interfaces.repl._list_models_sync", side_effect=OSError("Connection refused")):
+                app.update_autocomplete("/model set ")
+                self.assertFalse(autolist.display)
+                self.assertEqual(autolist.option_count, 0)
+
     async def test_accept_completion_file_mention(self) -> None:
         repl_mock = MagicMock()
         repl_mock.runtime.settings.model.name = "gemma4:26b"


### PR DESCRIPTION
### Description
- Implements autocompletion for models when typing `/model set ` in the interactive REPL.
- Uses `_list_models_sync` to query available Ollama models dynamically.
- Triggers `AgentHeader` update after model changes via `/model set`.
- Adds unit tests for autocomplete suggestions, prefix filtering, and error resilience.

### Validation
- `.venv/bin/python -m unittest discover -s tests` passed (33 tests).
- `mypy` type check passed.