### PR TITLE
feat: add /effort slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The REPL provides built-in slash commands for managing models, sessions, tasks, 
 | :--- | :--- | :--- |
 | `/help` | `/help` | Display the interactive help panel with command categories. |
 | `/model` | `/model [list \| set <model>]` | List available Ollama models (with tool support indicators) or switch the active model for the current session. |
+| `/effort` | `/effort [<level>]` | Show current reasoning effort or switch the thinking/reasoning effort level (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`) for the active session. |
 | `/params` | `/params [list \| set <parameter> <value>]` | Inspect active sampling parameters and resolution sources, or dynamically update parameter values for the active session. |
 | `/session` | `/session [list \| search <query> \| resume <id> \| new \| export [path] \| delete <id>]` | Manage persistent chat sessions. Search past conversations, resume previous threads, export to Markdown, or delete history. |
 | `/compact` | `/compact` (alias: `/compress`) | Manually compact conversation history into a structured summary to reclaim context window tokens. |

--- a/docs/cli_repl.md
+++ b/docs/cli_repl.md
@@ -150,6 +150,8 @@ Slash commands provide full application control directly within the REPL:
 | :--- | :--- | :--- |
 | `/help` | `/help` | Display interactive help panel categorized by feature. |
 | `/model` | `/model [list \| set <model>]` | List available Ollama models (with tool support indicators) or switch model mid-session. |
+| `/effort` | `/effort [<level>]` | Show current reasoning effort or change thinking/reasoning effort mid-session (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`). |
+| `/params` | `/params [list \| set <parameter> <value>]` | Inspect active sampling parameters and resolution sources, or dynamically update parameter values for the active session. |
 | `/session` | `/session [list \| search <query> \| resume <id> \| new \| export [path] \| delete <id>]` | Manage persistent chat sessions. Search past conversations, resume threads, export to Markdown, or delete history. |
 | `/compact` | `/compact` (alias: `/compress`) | Manually compact conversation history into a structured summary to reclaim context window tokens. |
 | `/task` | `/task [list \| create <id> \| run <id> [-y] \| delete <id>]` | Manage saved prompt tasks. `/task create` launches an interactive modal dialog. |

--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -409,6 +409,13 @@ class AgentRuntime:
         await self.reload()
         return f"Model set to {model_name}."
 
+    async def set_reasoning_effort(self, effort: str) -> str:
+        validated = validate_reasoning_effort(effort)
+        self.settings.model.reasoning_effort = validated
+        await asyncio.to_thread(save_settings, self.settings)
+        await self.reload()
+        return f"Reasoning effort set to {validated}."
+
     async def aclose(self) -> None:
         await self._exit_stack.aclose()
 

--- a/ollama_agent/interfaces/dispatch.py
+++ b/ollama_agent/interfaces/dispatch.py
@@ -25,7 +25,13 @@ from ..rag import (
 )
 from ..skills import SkillError, SkillsContext, create_skill, delete_skill, list_skills, show_skill
 from ..tasks.commands import CLIContext, TaskError, create_task, delete_task, list_tasks, run_task
-from .model_commands import list_models, set_model_param, show_model_params
+from .model_commands import (
+    list_models,
+    set_effort,
+    set_model_param,
+    show_effort,
+    show_model_params,
+)
 from .session_commands import (
     delete_session,
     export_session,
@@ -152,6 +158,8 @@ def build_repl_handlers(
     handle_session_export: Callable[[list[str]], Awaitable[None]] | None = None,
     handle_compact: Callable[[list[str]], Awaitable[None]] | None = None,
     get_runtime: Callable[[], Any] | None = None,
+    current_effort: Callable[[], str] = lambda: "",
+    switch_effort: Callable[[str], Awaitable[None]] | None = None,
 ) -> dict[str, REPLCommand]:
     """Build the REPL command registry for unified slash commands."""
 
@@ -163,6 +171,22 @@ def build_repl_handlers(
         if len(args) == 1 and args[0] != "list":
             return switch_model(args[0])
         console.print("[red]Usage: /model [list | set <model>][/red]")
+        return None
+
+    def handle_effort(args: list[str]) -> object:
+        if not args:
+            if get_runtime is not None:
+                show_effort(console, get_runtime())
+            else:
+                eff = current_effort()
+                console.print(
+                    f"Current reasoning effort: [bold cyan]{eff}[/bold cyan]\n"
+                    "[dim]Usage: /effort <level>[/dim]"
+                )
+            return None
+        target = args[1] if args[0] in ("set", "use", "switch") and len(args) > 1 else args[0]
+        if switch_effort is not None:
+            return switch_effort(target)
         return None
 
     def handle_params(args: list[str]) -> object:
@@ -355,6 +379,12 @@ def build_repl_handlers(
             "Model Management",
             "/model [list | set <model>]",
             handle_model,
+        ),
+        "/effort": REPLCommand(
+            "Show or set reasoning/thinking effort",
+            "Model Management",
+            "/effort [<level>]",
+            handle_effort,
         ),
         "/params": REPLCommand(
             "Manage model sampling parameters (list, set)",

--- a/ollama_agent/interfaces/model_commands.py
+++ b/ollama_agent/interfaces/model_commands.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ..agent import AgentRuntime
-from ..core import ModelCapabilityError, model_supports_tools
+from ..core import ALLOWED_REASONING_EFFORTS, ModelCapabilityError, model_supports_tools
 from ..settings import Settings, save_settings
 
 VALID_SAMPLING_PARAMS: dict[str, type] = {
@@ -125,6 +125,48 @@ async def set_model(
         return model_name
     except (ollama.ResponseError, OSError) as exc:
         console.print(f"[red]Failed to switch to model '{model_name}': {exc}[/red]")
+        return current
+
+
+def show_effort(console: Console, runtime: AgentRuntime) -> None:
+    """Print the current reasoning effort and model."""
+    effort = runtime.settings.model.reasoning_effort
+    model = runtime.settings.model.name
+    console.print(
+        f"Current reasoning effort: [bold cyan]{effort}[/bold cyan] [dim](model: {model})[/dim]\n"
+        "[dim]Usage: /effort <level> (e.g. low, medium, high, disabled, hide, enabled)[/dim]"
+    )
+
+
+async def set_effort(
+    console: Console,
+    effort: str,
+    *,
+    runtime: AgentRuntime,
+) -> str:
+    """Switch reasoning effort level, returning the new effort level."""
+    norm_effort = effort.lower().strip()
+    if norm_effort not in ALLOWED_REASONING_EFFORTS:
+        valid_list = ", ".join(ALLOWED_REASONING_EFFORTS)
+        console.print(
+            f"[red]Invalid reasoning effort '{effort}'. Allowed values: {valid_list}[/red]"
+        )
+        return runtime.settings.model.reasoning_effort
+
+    current = runtime.settings.model.reasoning_effort
+    if norm_effort == current:
+        console.print(f"[yellow]Already using reasoning effort '{norm_effort}'.[/yellow]")
+        return current
+
+    try:
+        await runtime.set_reasoning_effort(norm_effort)
+        console.print(
+            f"[green]✓ Switched reasoning effort from [cyan]{current}[/cyan] to [cyan]{norm_effort}[/cyan][/green]\n"
+            "[dim]Conversation preserved. Continue chatting.[/dim]"
+        )
+        return norm_effort
+    except (ollama.ResponseError, OSError, ValueError) as exc:
+        console.print(f"[red]Failed to switch reasoning effort to '{norm_effort}': {exc}[/red]")
         return current
 
 

--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -40,7 +40,7 @@ from ..rag import RAGContext, RAGManager, load_rag_database
 from ..skills import SkillsContext, create_skill
 from ..tasks.commands import CLIContext, TaskError, create_task
 from .dispatch import REPLCommand, build_repl_handlers, safe_call
-from .model_commands import _list_models_sync, set_model
+from .model_commands import _list_models_sync, set_effort, set_model
 from .session_commands import (
     compact_session,
     export_session,
@@ -57,6 +57,7 @@ _AT_MENTION_RE = re.compile(
 
 _ROOT_COMMANDS: list[tuple[str, str]] = [
     ("/model", "Manage models (list, set)"),
+    ("/effort", "Show or set reasoning/thinking effort"),
     ("/params", "Manage model sampling parameters (list, set)"),
     ("/session", "Manage chat sessions (list, search, resume, new, export, delete)"),
     ("/compact", "Compact conversation history into a summary"),
@@ -685,7 +686,7 @@ class OllamaAgentApp(App):
             self.update_yolo_ui()
         elif cmd == "/rag" and args and args[0] in ("load", "unload", "delete"):
             await self.repl.runtime.reload()
-        elif cmd == "/model" and args and args[0] == "set":
+        elif cmd in ("/model", "/effort"):
             self.query_one(AgentHeader).update_header()
 
     # ── Modal helpers ─────────────────────────────────────────────────────
@@ -831,6 +832,8 @@ class OllamaREPL:
                 handle_session_export=self._handle_session_export,
                 handle_compact=self._handle_compact,
                 get_runtime=lambda: self.runtime,
+                current_effort=lambda: self.runtime.settings.model.reasoning_effort,
+                switch_effort=self._switch_effort,
             )
         return self._commands
 
@@ -873,6 +876,9 @@ class OllamaREPL:
 
     async def _switch_model(self, model_name: str) -> None:
         await set_model(self.console, model_name, runtime=self.runtime)
+
+    async def _switch_effort(self, effort: str) -> None:
+        await set_effort(self.console, effort, runtime=self.runtime)
 
     async def _handle_new_session(self, args: list[str]) -> None:
         self.runtime.thread_id = new_session(self.console)

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -173,6 +173,13 @@ class TestAgentRuntimeComponents(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(runtime.settings.model.name, "qwen3:32b")
             self.assertIn("qwen3:32b", msg)
 
+            effort_msg = await runtime.set_reasoning_effort("high")
+            self.assertEqual(runtime.settings.model.reasoning_effort, "high")
+            self.assertIn("high", effort_msg)
+
+            with self.assertRaises(ValueError):
+                await runtime.set_reasoning_effort("invalid_effort")
+
         await runtime.aclose()
 
     async def test_agent_runtime_rag_active_instructions_and_tools(self) -> None:

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -99,6 +99,7 @@ class TestDispatchAndCLI(unittest.TestCase):
 
         self.assertIn("/help", handlers)
         self.assertIn("/model", handlers)
+        self.assertIn("/effort", handlers)
         self.assertIn("/yolo", handlers)
         self.assertIn("/new", handlers)
         self.assertIn("/compact", handlers)

--- a/tests/test_interfaces_commands.py
+++ b/tests/test_interfaces_commands.py
@@ -13,8 +13,10 @@ from ollama_agent.interfaces.dispatch import build_repl_handlers, render_repl_he
 from ollama_agent.interfaces.model_commands import (
     ensure_model_configured,
     list_models,
+    set_effort,
     set_model,
     set_model_param,
+    show_effort,
     show_model_params,
 )
 from ollama_agent.interfaces.session_commands import new_session
@@ -121,6 +123,47 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
             runtime.set_model.assert_awaited_once_with("qwen3:32b")
             self.assertIn("Switched", console.export_text())
 
+    def test_show_effort(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime = MagicMock()
+        runtime.settings.model.reasoning_effort = "medium"
+        runtime.settings.model.name = "llama3.2:3b"
+
+        show_effort(console, runtime)
+        out = console.export_text()
+        self.assertIn("Current reasoning effort", out)
+        self.assertIn("medium", out)
+        self.assertIn("llama3.2:3b", out)
+
+    async def test_set_effort_invalid(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime = MagicMock()
+        runtime.settings.model.reasoning_effort = "medium"
+
+        res = await set_effort(console, "super_extreme", runtime=runtime)
+        self.assertEqual(res, "medium")
+        self.assertIn("Invalid reasoning effort", console.export_text())
+
+    async def test_set_effort_same(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime = MagicMock()
+        runtime.settings.model.reasoning_effort = "high"
+
+        res = await set_effort(console, "high", runtime=runtime)
+        self.assertEqual(res, "high")
+        self.assertIn("Already using reasoning effort", console.export_text())
+
+    async def test_set_effort_success(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime = MagicMock()
+        runtime.settings.model.reasoning_effort = "medium"
+        runtime.set_reasoning_effort = AsyncMock()
+
+        res = await set_effort(console, "high", runtime=runtime)
+        self.assertEqual(res, "high")
+        runtime.set_reasoning_effort.assert_awaited_once_with("high")
+        self.assertIn("Switched reasoning effort", console.export_text())
+
     def test_show_model_params(self) -> None:
         console = Console(file=io.StringIO(), record=True)
         runtime = MagicMock()
@@ -194,27 +237,57 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
         )
 
         # /params
-        handlers["/params"].callback([])
+        handlers["/params"].handler([])
         out = console.export_text()
         self.assertIn("Active Model Parameters", out)
 
         # /params list
         console = Console(file=io.StringIO(), record=True)
-        handlers["/params"].callback(["list"])
+        handlers["/params"].handler(["list"])
         out_list = console.export_text()
         self.assertIn("Active Model Parameters", out_list)
 
         # /params set with missing args
         console = Console(file=io.StringIO(), record=True)
-        handlers["/params"].callback(["set", "temperature"])
+        handlers["/params"].handler(["set", "temperature"])
         out_missing = console.export_text()
         self.assertIn("Usage: /params set", out_missing)
 
         # /model does not handle params
         console = Console(file=io.StringIO(), record=True)
-        handlers["/model"].callback(["params"])
+        handlers["/model"].handler(["params"])
         out_model = console.export_text()
         self.assertIn("Usage: /model", out_model)
+
+    def test_effort_dispatch(self) -> None:
+        console = Console(file=io.StringIO(), record=True)
+        runtime = MagicMock()
+        runtime.settings.model.reasoning_effort = "medium"
+        runtime.settings.model.name = "llama3.2:3b"
+
+        handlers = build_repl_handlers(
+            task_ctx=MagicMock(),
+            skills_ctx=MagicMock(),
+            get_rag_ctx=MagicMock(),
+            console=console,
+            current_model=lambda: "llama3.2:3b",
+            base_url=lambda: "http://localhost:11434",
+            switch_model=AsyncMock(),
+            handle_exit=lambda _: None,
+            handle_new=AsyncMock(),
+            handle_task_create=lambda _: None,
+            handle_skill_create=lambda _: None,
+            handle_yolo=lambda _: None,
+            get_runtime=lambda: runtime,
+            current_effort=lambda: "medium",
+            switch_effort=AsyncMock(),
+        )
+
+        # /effort without args
+        handlers["/effort"].handler([])
+        out = console.export_text()
+        self.assertIn("Current reasoning effort", out)
+        self.assertIn("medium", out)
 
     def test_render_repl_help(self) -> None:
         console = Console(file=io.StringIO(), record=True)
@@ -237,6 +310,7 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Available Commands", out)
         self.assertIn("/help", out)
         self.assertIn("/model", out)
+        self.assertIn("/effort", out)
         self.assertIn("/task", out)
         self.assertIn("/skill", out)
         self.assertIn("/rag", out)
@@ -248,6 +322,7 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
         skills_ctx = MagicMock()
         rag_ctx = MagicMock()
         switch_model = AsyncMock()
+        switch_effort = AsyncMock()
         handle_task_create = MagicMock()
         handle_skill_create = MagicMock()
 
@@ -264,6 +339,8 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
             handle_task_create=handle_task_create,
             handle_skill_create=handle_skill_create,
             handle_yolo=lambda _: None,
+            current_effort=lambda: "medium",
+            switch_effort=switch_effort,
         )
 
         # 1. /model handler
@@ -273,6 +350,18 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
 
         await safe_call(handlers["/model"].handler, ["set", "llama3:8b"])
         switch_model.assert_awaited_with("llama3:8b")
+
+        # 1b. /effort handler
+        with patch("ollama_agent.interfaces.dispatch.show_effort") as mock_show_effort:
+            handlers["/effort"].handler([])
+            out_effort = console.export_text()
+            self.assertIn("Current reasoning effort", out_effort)
+
+        await safe_call(handlers["/effort"].handler, ["set", "high"])
+        switch_effort.assert_awaited_with("high")
+
+        await safe_call(handlers["/effort"].handler, ["low"])
+        switch_effort.assert_awaited_with("low")
 
         # 2. /task handler
         with patch("ollama_agent.interfaces.dispatch.list_tasks") as mock_list_tasks:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -518,8 +518,13 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
         def _toggle_yolo(args):
             repl_mock.runtime.yolo_mode = not repl_mock.runtime.yolo_mode
 
+        def _set_effort(args):
+            if args:
+                repl_mock.runtime.settings.model.reasoning_effort = args[0]
+
         repl_mock._get_commands.return_value = {
             "/yolo": REPLCommand(summary="toggle yolo", section="General", usage=None, handler=_toggle_yolo),
+            "/effort": REPLCommand(summary="manage effort", section="Model Management", usage=None, handler=_set_effort),
         }
 
         app = OllamaAgentApp(repl_mock)
@@ -566,6 +571,12 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
                 await pilot.pause()
                 self.assertEqual(len(list(chat_scroll.query(UserMessage))), 1)
                 self.assertEqual(len(list(chat_scroll.query(AgentResponse))), 1)
+
+            # 5. /effort command updates header
+            with patch.object(app.query_one(AgentHeader), "update_header") as mock_update_header:
+                await app._run_slash_command("/effort high")
+                mock_update_header.assert_called_once()
+                self.assertEqual(repl_mock.runtime.settings.model.reasoning_effort, "high")
 
     async def test_tui_streaming_renderer_events(self) -> None:
         repl_mock = MagicMock()


### PR DESCRIPTION
Adds the `/effort` slash command allowing users to inspect or switch thinking/reasoning effort mid-session while preserving context, and updates the TUI header and documentation.