### PR TITLE
feat: add keyboard navigation and shortcuts for tool approval dialog

### DIFF
--- a/ollama_agent/interfaces/repl.css
+++ b/ollama_agent/interfaces/repl.css
@@ -277,9 +277,37 @@ ToolApprovalWidget {
 
 .approval-btn {
     margin-right: 1;
-    min-width: 12;
+    min-width: 15;
     height: 1;
     border: none;
+}
+
+.approval-btn:focus {
+    text-style: bold;
+}
+
+#approve-btn:focus {
+    background: #34d399 !important;
+    color: #0d1117 !important;
+    text-style: bold;
+}
+
+#reject-btn:focus {
+    background: #f87171 !important;
+    color: #0d1117 !important;
+    text-style: bold;
+}
+
+#allow-btn:focus {
+    background: #38bdf8 !important;
+    color: #0d1117 !important;
+    text-style: bold;
+}
+
+#cancel-btn:focus {
+    background: #8b949e !important;
+    color: #0d1117 !important;
+    text-style: bold;
 }
 
 .approval-status {

--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -757,11 +757,18 @@ class OllamaAgentApp(App):
             except asyncio.CancelledError:
                 scroll.mount(SystemMessage("[bold #f87171]🛑 Execution interrupted by user.[/bold #f87171]"))
                 self._deferred_scroll()
-                self.query_one(ReplInput).focus()
+                inp = self.query_one(ReplInput)
+                inp.disabled = False
+                inp.focus()
+                footer.set_approval(False)
                 raise
             except Exception as e:
                 scroll.mount(SystemMessage(f"[bold #f87171]✕ Error:[/bold #f87171] [red]{e}[/red]"))
                 self._deferred_scroll()
+                inp = self.query_one(ReplInput)
+                inp.disabled = False
+                inp.focus()
+                footer.set_approval(False)
                 return
 
             # Check if the execution got interrupted
@@ -771,6 +778,9 @@ class OllamaAgentApp(App):
                 interrupt_val = state.interrupts[0].value
                 action_requests = interrupt_val.get("action_requests", [])
                 if action_requests:
+                    inp = self.query_one(ReplInput)
+                    inp.disabled = True
+                    footer.set_approval(True)
                     approval_widget = ToolApprovalWidget(
                         action_requests=action_requests,
                         app_ref=self,
@@ -779,6 +789,10 @@ class OllamaAgentApp(App):
                     )
                     agent_msg.mount(approval_widget)
                     self._deferred_scroll()
+            else:
+                inp = self.query_one(ReplInput)
+                inp.disabled = False
+                inp.focus()
         finally:
             self._is_generating = False
             footer.set_generating(False)

--- a/ollama_agent/interfaces/tui_components.py
+++ b/ollama_agent/interfaces/tui_components.py
@@ -76,6 +76,7 @@ class AgentFooter(Static):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._is_generating = False
+        self._is_approval = False
 
     def on_mount(self) -> None:
         self.update_footer()
@@ -84,8 +85,21 @@ class AgentFooter(Static):
         self._is_generating = is_generating
         self.update_footer()
 
+    def set_approval(self, is_approval: bool) -> None:
+        self._is_approval = is_approval
+        self.update_footer()
+
     def update_footer(self) -> None:
-        if self._is_generating:
+        if self._is_approval:
+            self.update(
+                "[bold #fbbf24]⚠ Approval required:[/bold #fbbf24]   "
+                "[dim]y[/dim] [bold #8b949e]approve[/bold #8b949e]   "
+                "[dim]n[/dim] [bold #8b949e]reject[/bold #8b949e]   "
+                "[dim]a[/dim] [bold #8b949e]allow session[/bold #8b949e]   "
+                "[dim]esc[/dim] [bold #8b949e]cancel[/bold #8b949e]   "
+                "[dim]←→[/dim] [bold #8b949e]select[/bold #8b949e]"
+            )
+        elif self._is_generating:
             self.update(
                 "[bold #38bdf8]⟡ Generating response...[/bold #38bdf8]   "
                 "[dim]press [bold #f87171]esc[/bold #f87171] or [bold #f87171]^C[/bold #f87171] to interrupt[/dim]"
@@ -543,6 +557,8 @@ class SkillCreateModal(ModalScreen):
 class ToolApprovalWidget(Container):
     """Inline widget prompting the user for approval of sensitive tool calls."""
 
+    BUTTON_IDS = ["approve-btn", "reject-btn", "allow-btn", "cancel-btn"]
+
     def __init__(self, action_requests: list[dict[str, Any]], app_ref: OllamaAgentApp, scroll: Any, agent_msg: AgentResponse, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.action_requests = action_requests
@@ -560,10 +576,13 @@ class ToolApprovalWidget(Container):
 
         with Horizontal(classes="approval-buttons") as buttons:
             self.buttons_container = buttons
-            yield Button("Approve [y]", id="approve-btn", variant="success", classes="approval-btn")
-            yield Button("Reject [n]", id="reject-btn", variant="error", classes="approval-btn")
-            yield Button("Allow Session [a]", id="allow-btn", variant="primary", classes="approval-btn")
-            yield Button("Cancel [esc]", id="cancel-btn", classes="approval-btn")
+            yield Button("Approve (y)", id="approve-btn", variant="success", classes="approval-btn")
+            yield Button("Reject (n)", id="reject-btn", variant="error", classes="approval-btn")
+            yield Button("Allow Session (a)", id="allow-btn", variant="primary", classes="approval-btn")
+            yield Button("Cancel (c)", id="cancel-btn", classes="approval-btn")
+
+    def on_mount(self) -> None:
+        self.query_one("#approve-btn", Button).focus()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         event.stop()
@@ -571,18 +590,40 @@ class ToolApprovalWidget(Container):
 
     def on_key(self, event: events.Key) -> None:
         key = event.key.lower()
-        if key in ("y",):
+        if key == "y":
             event.stop()
             self._handle_decision("approve-btn")
-        elif key in ("n",):
+        elif key == "n":
             event.stop()
             self._handle_decision("reject-btn")
-        elif key in ("a",):
+        elif key == "a":
             event.stop()
             self._handle_decision("allow-btn")
-        elif key in ("escape", "c"):
+        elif key == "c":
             event.stop()
             self._handle_decision("cancel-btn")
+        elif key in ("left", "up", "shift+tab"):
+            event.stop()
+            event.prevent_default()
+            focused = self.app.focused
+            current_id = focused.id if focused and focused.id in self.BUTTON_IDS else None
+            idx = self.BUTTON_IDS.index(current_id) if current_id else 0
+            prev_id = self.BUTTON_IDS[(idx - 1) % len(self.BUTTON_IDS)]
+            self.query_one(f"#{prev_id}", Button).focus()
+        elif key in ("right", "down", "tab"):
+            event.stop()
+            event.prevent_default()
+            focused = self.app.focused
+            current_id = focused.id if focused and focused.id in self.BUTTON_IDS else None
+            idx = self.BUTTON_IDS.index(current_id) if current_id else -1
+            next_id = self.BUTTON_IDS[(idx + 1) % len(self.BUTTON_IDS)]
+            self.query_one(f"#{next_id}", Button).focus()
+        elif key in ("enter", "space"):
+            focused = self.app.focused
+            decision = focused.id if focused and focused.id in self.BUTTON_IDS else "approve-btn"
+            event.stop()
+            event.prevent_default()
+            self._handle_decision(decision)
 
     def _handle_decision(self, decision_type: str | None) -> None:
         if not self.buttons_container:
@@ -624,6 +665,12 @@ class ToolApprovalWidget(Container):
             status_text = "[bold #f87171]✗ Cancelled[/bold #f87171]"
 
         self.mount(Static(f"  {status_text}", classes="approval-status"))
+
+        inp = self.app_ref.query_one(ReplInput)
+        inp.disabled = False
+
+        footer = self.app_ref.query_one(AgentFooter)
+        footer.set_approval(False)
 
         self.app_ref._current_worker = self.app_ref.run_worker(
             self.app_ref._handle_approval_decision(decisions, self.scroll, self.agent_msg)

--- a/ollama_agent/streaming/console_renderer.py
+++ b/ollama_agent/streaming/console_renderer.py
@@ -141,20 +141,20 @@ class ConsoleStreamingRenderer(StreamingRenderer):
             while True:
                 prompt_msg = (
                     "  [bold cyan]Choose action:[/bold cyan] "
-                    "([bold]a[/bold])pprove / ([bold]r[/bold])eject / "
-                    "allow ([bold]s[/bold])ession / ([bold]c[/bold])ancel: "
+                    "Approve ([bold]y[/bold]) / Reject ([bold]n[/bold]) / "
+                    "Allow Session ([bold]a[/bold]) / Cancel ([bold]c[/bold]): "
                 )
                 self.console.print(prompt_msg, end="")
                 self.console.file.flush()
                 choice = (await asyncio.to_thread(input)).strip().lower()
-                if choice == "a":
+                if choice == "y":
                     return [{"type": "approve"} for _ in action_requests]
-                elif choice == "r":
+                elif choice == "n":
                     return [{
                         "type": "reject",
                         "message": f"User rejected executing tool '{r['name']}'."
                     } for r in action_requests]
-                elif choice == "s":
+                elif choice == "a":
                     for req in action_requests:
                         runtime.auto_approved_tools.add(req["name"])
                     return [{"type": "approve"} for _ in action_requests]
@@ -162,7 +162,7 @@ class ConsoleStreamingRenderer(StreamingRenderer):
                     self.console.print("  [red]✗ Cancelled[/red]\n")
                     raise KeyboardInterrupt()
                 else:
-                    self.console.print("  [red]Invalid choice. Please enter 'a', 'r', 's', or 'c'.[/red]")
+                    self.console.print("  [red]Invalid choice. Please enter 'y', 'n', 'a', or 'c'.[/red]")
         except (EOFError, KeyboardInterrupt):
             self.console.print("  [red]✗ Cancelled[/red]\n")
             raise KeyboardInterrupt()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -80,6 +80,13 @@ class TestTUIComponents(unittest.IsolatedAsyncioTestCase):
         gen_text = str(footer.render())
         self.assertIn("Generating response", gen_text)
 
+        footer.set_approval(True)
+        appr_text = str(footer.render())
+        self.assertIn("Approval required", appr_text)
+        self.assertIn("approve", appr_text)
+        self.assertIn("reject", appr_text)
+
+        footer.set_approval(False)
         footer.set_generating(False)
         self.assertIn("interrupt", str(footer.render()))
 
@@ -235,6 +242,9 @@ class TestTUIComponents(unittest.IsolatedAsyncioTestCase):
 
         app = ApprovalApp()
         async with app.run_test() as pilot:
+            # Auto-focused on approve-btn
+            self.assertEqual(app.focused.id, "approve-btn")
+
             # Test keypress 'y' for Approve
             key_event = events.Key("y", "y")
             widget.on_key(key_event)
@@ -242,6 +252,92 @@ class TestTUIComponents(unittest.IsolatedAsyncioTestCase):
             app_ref_mock._handle_approval_decision.assert_called_once()
             decisions = app_ref_mock._handle_approval_decision.call_args[0][0]
             self.assertEqual(decisions, [{"type": "approve"}])
+
+    async def test_tool_approval_widget_navigation_and_shortcuts(self) -> None:
+        # Test button labels
+        reqs = [{"name": "write_file", "args": {"path": "test.txt"}}]
+        widget = ToolApprovalWidget(
+            action_requests=reqs,
+            app_ref=MagicMock(),
+            scroll=MagicMock(),
+            agent_msg=AgentResponse(),
+        )
+        buttons = list(widget.query(Button))
+        # Compose buttons
+        composed_buttons = [w for w in widget.compose() if isinstance(w, Button) or hasattr(w, "query")]
+
+        # Test single direct shortcuts (y, n, a, c)
+        for shortcut, expected_type in [
+            ("y", "approve"),
+            ("n", "reject"),
+            ("a", "approve"),
+            ("c", "reject"),
+        ]:
+            app_ref_mock = MagicMock()
+            app_ref_mock.repl.runtime.auto_approved_tools = set()
+            widget = ToolApprovalWidget(
+                action_requests=[{"name": "execute", "args": {"cmd": "ls"}}],
+                app_ref=app_ref_mock,
+                scroll=MagicMock(),
+                agent_msg=AgentResponse(),
+            )
+
+            class ShortcutApp(App):
+                def compose(self) -> ComposeResult:
+                    yield widget
+
+            app = ShortcutApp()
+            async with app.run_test() as pilot:
+                widget.on_key(events.Key(shortcut, shortcut))
+                app_ref_mock._handle_approval_decision.assert_called_once()
+                decisions = app_ref_mock._handle_approval_decision.call_args[0][0]
+                self.assertEqual(decisions[0]["type"], expected_type)
+                if shortcut == "a":
+                    self.assertIn("execute", app_ref_mock.repl.runtime.auto_approved_tools)
+
+        # Test arrow key navigation between buttons
+        app_ref_mock = MagicMock()
+        widget = ToolApprovalWidget(
+            action_requests=[{"name": "execute", "args": {"cmd": "ls"}}],
+            app_ref=app_ref_mock,
+            scroll=MagicMock(),
+            agent_msg=AgentResponse(),
+        )
+
+        class NavApp(App):
+            def compose(self) -> ComposeResult:
+                yield widget
+
+        app = NavApp()
+        async with app.run_test() as pilot:
+            self.assertEqual(app.focused.id, "approve-btn")
+
+            # Press Right arrow -> reject-btn
+            widget.on_key(events.Key("right", "right"))
+            self.assertEqual(app.focused.id, "reject-btn")
+
+            # Press Right arrow -> allow-btn
+            widget.on_key(events.Key("right", "right"))
+            self.assertEqual(app.focused.id, "allow-btn")
+
+            # Press Right arrow -> cancel-btn
+            widget.on_key(events.Key("right", "right"))
+            self.assertEqual(app.focused.id, "cancel-btn")
+
+            # Press Right arrow (wrap around) -> approve-btn
+            widget.on_key(events.Key("right", "right"))
+            self.assertEqual(app.focused.id, "approve-btn")
+
+            # Press Left arrow (wrap around) -> cancel-btn
+            widget.on_key(events.Key("left", "left"))
+            self.assertEqual(app.focused.id, "cancel-btn")
+
+            # Press Enter on focused button (cancel-btn)
+            widget.on_key(events.Key("enter", "\r"))
+            app_ref_mock._handle_approval_decision.assert_called_once()
+            decisions = app_ref_mock._handle_approval_decision.call_args[0][0]
+            self.assertEqual(decisions[0]["type"], "reject")
+            self.assertEqual(decisions[0]["message"], "User cancelled the execution.")
 
 
     async def test_task_create_modal(self) -> None:


### PR DESCRIPTION
## Description

This PR adds full keyboard navigation and direct shortcuts to the Human-in-the-Loop (HITL) tool approval dialog.

### Key Changes
- **Automatic focus**: `ToolApprovalWidget` auto-focuses the primary action (`Approve (y)`) upon appearance and temporarily disables the main chat input to prevent prompt interception.
- **Direct shortcuts**: Adds single direct keys:
  - `y`: Approve
  - `n`: Reject
  - `a`: Allow for Session
  - `c`: Cancel
- **Button labels**: Explicitly indicator format: `Approve (y)`, `Reject (n)`, `Allow Session (a)`, `Cancel (c)`.
- **Keyboard navigation**: Supports `Left`/`Right`/`Up`/`Down` and `Tab`/`Shift+Tab` circular focus cycling with high-contrast button focus styling, activated by `Enter` or `Space`.
- **Footer status**: Updates `AgentFooter` to show live approval key guides.
- **Console renderer**: Aligns CLI non-interactive streaming prompts with the same `y`, `n`, `a`, `c` convention.