### PR TITLE
feat(cli): refactor subcommands to use standard positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@
 - 🛡️ **Human-in-the-Loop (HITL) & YOLO Mode**: Interactive terminal approval widget before executing shell commands or editing files, with full bypass available via YOLO mode (`-y` or `/yolo`).
 - 📁 **Interactive `@-mentions`**: Reference local files or entire directory trees directly in prompts (e.g. `@src/main.py`, `@"data folder"`, `@.`) with path autocompletion, multimodal encoding, and binary safety.
 - 💾 **SQLite-Backed Sessions**: Durable conversation checkpoints in `~/.ollama-agent/history.db` with instant resumption (`/session resume <id>`), markdown export (`/session export`), and history management.
-- 📋 **Saved Tasks**: Save reusable prompts as YAML templates and execute them on demand via CLI (`task-run`) or interactive REPL modals (`/task run`).
+- 📋 **Saved Tasks**: Save reusable prompts as YAML templates and execute them on demand via CLI (`task run`) or interactive REPL modals (`/task run`).
 - 🧩 **Agent Skills Standard**: Extend the agent with modular skills following the [Agent Skills specification](https://agentskills.io/specification) using progressive disclosure.
 - 📚 **Local RAG Engine**: Embed and index documents into local Qdrant vector collections with automated semantic retrieval via the agent's `rag_search` tool.
 - 🧠 **Persistent Memory & Guidelines**: Cross-session user memory (`MEMORY.md`), automatic discovery of project-level guidelines (`AGENTS.md`), and **Episodic Memory** to search past conversations and solutions (`search_past_conversations` tool and `/session search`).
-- 🔌 **Model Context Protocol (MCP)**: Attach MCP servers (`mcp.json` or `mcp_servers.json`) directly to the main agent across `stdio`, `http`, and `sse` transports, with real-time status inspection via `/mcp` and `mcp-list`.
+- 🔌 **Model Context Protocol (MCP)**: Attach MCP servers (`mcp.json` or `mcp_servers.json`) directly to the main agent across `stdio`, `http`, and `sse` transports, with real-time status inspection via `/mcp` and `mcp list`.
 - 🤖 **Specialized Subagents**: Configure isolated subagents in `settings.yaml` with their own model, system prompt, and dedicated MCP tool servers.
 
 ---
@@ -333,23 +333,23 @@ In addition to top-level flags, Ollama Agent provides dedicated CLI subcommands 
 
 | Domain | Subcommand | Example Usage | Description |
 | :--- | :--- | :--- | :--- |
-| **Sessions** | `session-list` | `ollama-agent session-list` | List all saved chat sessions. |
-| | `session-search` | `ollama-agent session-search "sqlite fix"` | Search past sessions by keyword. |
-| | `session-export` | `ollama-agent session-export <id> -o export.md` | Export a session to Markdown. |
-| | `session-delete` | `ollama-agent session-delete <id>` | Delete a session from SQLite history. |
-| **Tasks** | `task-list` | `ollama-agent task-list` | List all saved YAML tasks. |
-| | `task-create` | `ollama-agent task-create review --title "..." --task-prompt "..."` | Create a reusable task. |
-| | `task-run` | `ollama-agent task-run review -y` | Execute a task from CLI. |
-| | `task-delete` | `ollama-agent task-delete review` | Delete a saved task. |
-| **Skills** | `skill-list` | `ollama-agent skill-list` | List all discovered agent skills. |
-| | `skill-show` | `ollama-agent skill-show <id>` | Display skill metadata & instructions. |
-| | `skill-create` | `ollama-agent skill-create <id> --name "..." --description "..." --instructions "..."` | Create a new skill directory & `SKILL.md`. |
-| | `skill-delete` | `ollama-agent skill-delete <id>` | Delete a skill directory. |
-| **RAG** | `rag-list` | `ollama-agent rag-list` | List all local RAG vector databases. |
-| | `rag-create` | `ollama-agent rag-create docs-kb` | Create a new Qdrant vector database. |
-| | `rag-add` | `ollama-agent rag-add docs-kb ./docs --dir` | Index a file or directory into a RAG collection. |
-| | `rag-delete` | `ollama-agent rag-delete docs-kb` | Delete a RAG database. |
-| **MCP** | `mcp-list` | `ollama-agent mcp-list` | List configured MCP servers and check their connection health. |
+| **Sessions** | `session list` | `ollama-agent session list` | List all saved chat sessions. |
+| | `session search` | `ollama-agent session search "sqlite fix"` | Search past sessions by keyword. |
+| | `session export` | `ollama-agent session export <id> -o export.md` | Export a session to Markdown. |
+| | `session delete` | `ollama-agent session delete <id>` | Delete a session from SQLite history. |
+| **Tasks** | `task list` | `ollama-agent task list` | List all saved YAML tasks. |
+| | `task create` | `ollama-agent task create review --title "..." --task-prompt "..."` | Create a reusable task. |
+| | `task run` | `ollama-agent task run review -y` | Execute a task from CLI. |
+| | `task delete` | `ollama-agent task delete review` | Delete a saved task. |
+| **Skills** | `skill list` | `ollama-agent skill list` | List all discovered agent skills. |
+| | `skill show` | `ollama-agent skill show <id>` | Display skill metadata & instructions. |
+| | `skill create` | `ollama-agent skill create <id> --name "..." --description "..." --instructions "..."` | Create a new skill directory & `SKILL.md`. |
+| | `skill delete` | `ollama-agent skill delete <id>` | Delete a skill directory. |
+| **RAG** | `rag list` | `ollama-agent rag list` | List all local RAG vector databases. |
+| | `rag create` | `ollama-agent rag create docs-kb` | Create a new Qdrant vector database. |
+| | `rag add` | `ollama-agent rag add docs-kb ./docs --dir` | Index a file or directory into a RAG collection. |
+| | `rag delete` | `ollama-agent rag delete docs-kb` | Delete a RAG database. |
+| **MCP** | `mcp list` | `ollama-agent mcp list` | List configured MCP servers and check their connection health. |
 
 ---
 
@@ -405,12 +405,12 @@ All conversations are saved to a local SQLite database at `~/.ollama-agent/histo
 
 | Action | REPL Command | CLI Command | Description |
 | :--- | :--- | :--- | :--- |
-| **List Sessions** | `/session list` | `ollama-agent session-list` | Display saved sessions with thread IDs, step counts, and active status. |
-| **Search Sessions** | `/session search <query>` | `ollama-agent session-search <query>` | Search across past chat sessions and conversations by keyword. |
+| **List Sessions** | `/session list` | `ollama-agent session list` | Display saved sessions with thread IDs, step counts, and active status. |
+| **Search Sessions** | `/session search <query>` | `ollama-agent session search <query>` | Search across past chat sessions and conversations by keyword. |
 | **Resume Session** | `/session resume <id>` | — | Resume a past conversation by exact ID or prefix, restoring message history into the viewport. |
 | **New Session** | `/session new` (or `/new`, `/clear`) | — | Initialize a fresh conversation session with a new thread ID and clear the screen. |
-| **Export Session** | `/session export [path]` | `ollama-agent session-export <id> [-o path]` | Export conversation history to a structured Markdown document. |
-| **Delete Session** | `/session delete <id>` | `ollama-agent session-delete <id>` | Delete session checkpoints and metadata from the SQLite database. |
+| **Export Session** | `/session export [path]` | `ollama-agent session export <id> [-o path]` | Export conversation history to a structured Markdown document. |
+| **Delete Session** | `/session delete <id>` | `ollama-agent session delete <id>` | Delete session checkpoints and metadata from the SQLite database. |
 
 > [!TIP]
 > In the REPL, typing `/session resume ` or `/session delete ` dynamically lists and autocompletes available session IDs.
@@ -418,7 +418,7 @@ All conversations are saved to a local SQLite database at `~/.ollama-agent/histo
 ### 5. Episodic Memory & Conversation Recall
 Allows the AI agent to search and recall past conversation sessions, past troubleshooting steps, and previous architectural decisions stored in `~/.ollama-agent/history.db`:
 - **Autonomous Agent Tool**: The `search_past_conversations` tool is available to the agent so it can query prior sessions on demand when asked about past context (e.g., *"how did we resolve the database migration issue yesterday?"*).
-- **User Discovery**: Users can also search past sessions manually via `/session search <query>` in the REPL or `ollama-agent session-search <query>` in the CLI.
+- **User Discovery**: Users can also search past sessions manually via `/session search <query>` in the REPL or `ollama-agent session search <query>` in the CLI.
 
 ---
 
@@ -432,20 +432,20 @@ Tasks are reusable prompt templates stored as YAML files in `~/.ollama-agent/tas
 
 ```bash
 # Create a task
-ollama-agent task-create code-review \
+ollama-agent task create code-review \
     --title "Code Review Assistant" \
     --task-prompt "Review the git diff against main and highlight bugs, complexity, and styling issues." \
     -m "gemma4:26b" \
     -e "high"
 
 # List saved tasks
-ollama-agent task-list
+ollama-agent task list
 
 # Run a task (with optional YOLO mode)
-ollama-agent task-run code-review -y
+ollama-agent task run code-review -y
 
 # Delete a task
-ollama-agent task-delete code-review
+ollama-agent task delete code-review
 ```
 
 #### 2. REPL Task Management & Modal Dialogs
@@ -504,10 +504,10 @@ description: Guidelines and best practices for designing RESTful and OpenAPI com
 
 | Action | REPL Command | CLI Command |
 | :--- | :--- | :--- |
-| **List Skills** | `/skill list` | `ollama-agent skill-list` |
-| **Show Skill** | `/skill show <id>` | `ollama-agent skill-show <id>` |
-| **Create Skill** | `/skill create <id>` *(opens interactive modal)* | `ollama-agent skill-create <id> --name "..." --description "..." --instructions "..."` |
-| **Delete Skill** | `/skill delete <id>` | `ollama-agent skill-delete <id>` |
+| **List Skills** | `/skill list` | `ollama-agent skill list` |
+| **Show Skill** | `/skill show <id>` | `ollama-agent skill show <id>` |
+| **Create Skill** | `/skill create <id>` *(opens interactive modal)* | `ollama-agent skill create <id> --name "..." --description "..." --instructions "..."` |
+| **Delete Skill** | `/skill delete <id>` | `ollama-agent skill delete <id>` |
 
 > [!NOTE]
 > `SKILL.md` files must be under 10 MB. Descriptions longer than 1,024 characters are truncated automatically during skill indexing.
@@ -522,9 +522,9 @@ Local RAG empowers the agent to index documents into local Qdrant vector databas
 
 ```bash
 # CLI: Create, list, and delete databases
-ollama-agent rag-create project-docs
-ollama-agent rag-list
-ollama-agent rag-delete project-docs
+ollama-agent rag create project-docs
+ollama-agent rag list
+ollama-agent rag delete project-docs
 ```
 
 Inside REPL:
@@ -541,8 +541,8 @@ Inside REPL:
 
 ```bash
 # CLI: Index a single file or an entire directory
-ollama-agent rag-add project-docs ./docs/architecture.md
-ollama-agent rag-add project-docs ./src --dir
+ollama-agent rag add project-docs ./docs/architecture.md
+ollama-agent rag add project-docs ./src --dir
 ```
 
 Inside REPL:
@@ -605,7 +605,7 @@ Create `~/.ollama-agent/mcp.json` (or `mcp_servers.json`):
 
 - **Supported Transports**: `stdio` (subprocess execution), `http`, and `sse` (remote endpoints).
 - **Environment Substitution**: `${VAR_NAME}` (and `%VAR_NAME%`) syntax injects host environment variables; servers with missing required variables are skipped gracefully with a log warning.
-- **Server Status Inspection**: Run `/mcp` in the interactive REPL or `ollama-agent mcp-list` from the CLI to check connection status, health, and discovered tools with color-coded status badges (`● Active` / `● Failed`).
+- **Server Status Inspection**: Run `/mcp` in the interactive REPL or `ollama-agent mcp list` from the CLI to check connection status, health, and discovered tools with color-coded status badges (`● Active` / `● Failed`).
 
 ---
 

--- a/docs/cli_repl.md
+++ b/docs/cli_repl.md
@@ -65,10 +65,10 @@ ollama-agent --rag project-docs -p "How is authentication configured in this rep
 #### 1. Task Commands
 ```bash
 # List all saved tasks
-ollama-agent task-list
+ollama-agent task list
 
 # Create a new saved task
-ollama-agent task-create code-review \
+ollama-agent task create code-review \
     --title "Code Review Assistant" \
     --task-prompt "Review the git diff against main and highlight bugs, complexity, and styling issues." \
     -m "gemma4:26b" \
@@ -76,66 +76,66 @@ ollama-agent task-create code-review \
     [--force]
 
 # Execute a saved task (with optional YOLO mode)
-ollama-agent task-run code-review -y
+ollama-agent task run code-review -y
 
 # Delete a saved task
-ollama-agent task-delete code-review
+ollama-agent task delete code-review
 ```
 
 #### 2. RAG Commands
 ```bash
 # List all RAG vector databases
-ollama-agent rag-list
+ollama-agent rag list
 
 # Create a new RAG database
-ollama-agent rag-create project-docs
+ollama-agent rag create project-docs
 
 # Ingest a single file or an entire directory
-ollama-agent rag-add project-docs ./docs/architecture.md
-ollama-agent rag-add project-docs ./src --dir
+ollama-agent rag add project-docs ./docs/architecture.md
+ollama-agent rag add project-docs ./src --dir
 
 # Delete a RAG database
-ollama-agent rag-delete project-docs
+ollama-agent rag delete project-docs
 ```
 
 #### 3. Skill Commands
 ```bash
 # List all available skills
-ollama-agent skill-list
+ollama-agent skill list
 
 # Show details and instructions for a skill
-ollama-agent skill-show api-design
+ollama-agent skill show api-design
 
 # Create a new skill
-ollama-agent skill-create api-design \
+ollama-agent skill create api-design \
     --name "API Design Guidelines" \
     --description "RESTful and OpenAPI standards" \
     --instructions "Ensure all endpoints use nouns and camelCase properties." \
     [--force]
 
 # Delete a skill
-ollama-agent skill-delete api-design
+ollama-agent skill delete api-design
 ```
 
 #### 4. Session Commands
 ```bash
 # List all saved chat sessions with step counts
-ollama-agent session-list
+ollama-agent session list
 
 # Search past sessions by keyword
-ollama-agent session-search "dockerize fastapi"
+ollama-agent session search "dockerize fastapi"
 
 # Export a session to a Markdown document
-ollama-agent session-export 4d7e2a1b -o ./exports/session_summary.md
+ollama-agent session export 4d7e2a1b -o ./exports/session_summary.md
 
 # Delete a session from SQLite history
-ollama-agent session-delete 4d7e2a1b
+ollama-agent session delete 4d7e2a1b
 ```
 
 #### 5. MCP (Model Context Protocol) Commands
 ```bash
 # List all configured MCP servers and check their connection status
-ollama-agent mcp-list
+ollama-agent mcp list
 ```
 
 ---

--- a/docs/mcp_subagents.md
+++ b/docs/mcp_subagents.md
@@ -63,7 +63,7 @@ You can check configured MCP servers, test connectivity, and inspect available t
 
 Or via CLI:
 ```bash
-ollama-agent mcp-list
+ollama-agent mcp list
 ```
 
 This displays a color-coded status table showing:

--- a/docs/rag.md
+++ b/docs/rag.md
@@ -90,12 +90,12 @@ RAG databases can be managed via the CLI or directly within the interactive REPL
 
 | Action | CLI Command | REPL Command | Description |
 | :--- | :--- | :--- | :--- |
-| **List Databases** | `ollama-agent rag-list` | `/rag list` | List all available RAG databases and active status. |
-| **Create Database** | `ollama-agent rag-create <name>` | `/rag create <name>` | Create a new empty vector database. |
+| **List Databases** | `ollama-agent rag list` | `/rag list` | List all available RAG databases and active status. |
+| **Create Database** | `ollama-agent rag create <name>` | `/rag create <name>` | Create a new empty vector database. |
 | **Load Database** | — | `/rag load <name>` | Load a database into active memory for the session. |
 | **Unload Database** | — | `/rag unload` | Unload the currently active database. |
-| **Index Documents** | `ollama-agent rag-add <db> <path> [--dir]` | `/rag add <path> [--dir]` | Add a single file or directory (`--dir`) to a database. |
-| **Delete Database** | `ollama-agent rag-delete <name>` | `/rag delete <name>` | Delete a RAG database directory permanently. |
+| **Index Documents** | `ollama-agent rag add <db> <path> [--dir]` | `/rag add <path> [--dir]` | Add a single file or directory (`--dir`) to a database. |
+| **Delete Database** | `ollama-agent rag delete <name>` | `/rag delete <name>` | Delete a RAG database directory permanently. |
 | **Database Status** | — | `/rag status` (or `/rag`) | Display current loaded database status in REPL. |
 
 ### CLI Auto-Load Flag

--- a/docs/skills_tasks_memory.md
+++ b/docs/skills_tasks_memory.md
@@ -61,10 +61,10 @@ Skills can be managed via the CLI, REPL slash commands, or interactive TUI modal
 
 | Action | CLI Command | REPL Slash Command | Description |
 | :--- | :--- | :--- | :--- |
-| **List Skills** | `ollama-agent skill-list` | `/skill list` (or `/skill`) | List all available skills and descriptions. |
-| **Show Skill** | `ollama-agent skill-show <id>` | `/skill show <id>` | View raw contents and instructions of `SKILL.md`. |
-| **Create Skill** | `ollama-agent skill-create <id> --name <n> --description <d> --instructions <i> [--force]` | `/skill create <id>` *(launches modal)* | Create a new skill directory and `SKILL.md`. |
-| **Delete Skill** | `ollama-agent skill-delete <id>` | `/skill delete <id>` | Delete a skill directory permanently. |
+| **List Skills** | `ollama-agent skill list` | `/skill list` (or `/skill`) | List all available skills and descriptions. |
+| **Show Skill** | `ollama-agent skill show <id>` | `/skill show <id>` | View raw contents and instructions of `SKILL.md`. |
+| **Create Skill** | `ollama-agent skill create <id> --name <n> --description <d> --instructions <i> [--force]` | `/skill create <id>` *(launches modal)* | Create a new skill directory and `SKILL.md`. |
+| **Delete Skill** | `ollama-agent skill delete <id>` | `/skill delete <id>` | Delete a skill directory permanently. |
 
 ---
 
@@ -93,13 +93,13 @@ reasoning_effort: "medium"
 
 | Action | CLI Command | REPL Slash Command | Description |
 | :--- | :--- | :--- | :--- |
-| **List Tasks** | `ollama-agent task-list` | `/task list` (or `/task`) | List all saved tasks. |
-| **Create Task** | `ollama-agent task-create <id> --title <t> --task-prompt <p> [-m <model>] [-e <effort>] [--force]` | `/task create <id>` *(launches modal)* | Save a new task template. |
-| **Run Task** | `ollama-agent task-run <id> [-y]` | `/task run <id> [-y]` | Execute a saved task non-interactively or in REPL. |
-| **Delete Task** | `ollama-agent task-delete <id>` | `/task delete <id>` | Delete a saved task definition. |
+| **List Tasks** | `ollama-agent task list` | `/task list` (or `/task`) | List all saved tasks. |
+| **Create Task** | `ollama-agent task create <id> --title <t> --task-prompt <p> [-m <model>] [-e <effort>] [--force]` | `/task create <id>` *(launches modal)* | Save a new task template. |
+| **Run Task** | `ollama-agent task run <id> [-y]` | `/task run <id> [-y]` | Execute a saved task non-interactively or in REPL. |
+| **Delete Task** | `ollama-agent task delete <id>` | `/task delete <id>` | Delete a saved task definition. |
 
 ### Task Execution Behavior
-When running a task (`task-run <id>` or `/task run <id>`):
+When running a task (`task run <id>` or `/task run <id>`):
 1. `TaskManager` resolves the task ID or prefix.
 2. The runtime temporarily overrides `settings.model.name` and `settings.model.reasoning_effort` with the values defined in the task.
 3. The prompt is streamed non-interactively or inside the interactive REPL session with live tool tracking.
@@ -193,5 +193,5 @@ Users can search conversation history directly from the terminal:
 | Interface | Command | Description |
 | :--- | :--- | :--- |
 | **REPL Slash Command** | `/session search <query>` | Search all saved chat sessions and display matching snippets in a Rich table. |
-| **CLI Command** | `ollama-agent session-search <query>` | Query past sessions non-interactively from the shell. |
+| **CLI Command** | `ollama-agent session search <query>` | Query past sessions non-interactively from the shell. |
 | **Resume Matched Session** | `/session resume <id>` | Resume a discovered session by thread ID. |

--- a/ollama_agent/i18n/locales/de.json
+++ b/ollama_agent/i18n/locales/de.json
@@ -380,5 +380,11 @@
   "Invalid configuration or missing environment variables": "Ungültige Konfiguration oder fehlende Umgebungsvariablen",
   "Connection timed out ({timeout}s)": "Verbindungszeitüberschreitung ({timeout}s)",
   "Error reading MCP configuration {path}: {exc}": "Fehler beim Lesen der MCP-Konfiguration {path}: {exc}",
-  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Unbekannter MCP-Unterbefehl '{sub}'. Verwendung: /mcp [list]"
+  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Unbekannter MCP-Unterbefehl '{sub}'. Verwendung: /mcp [list]",
+  "Run 'ollama-agent <command> -h' for more details on a specific command.": "Führen Sie 'ollama-agent <command> -h' aus, um weitere Details zu einem bestimmten Befehl anzuzeigen.",
+  "Run 'ollama-agent task <subcommand> -h' for more details on a subcommand.": "Führen Sie 'ollama-agent task <subcommand> -h' aus, um weitere Details zu einem Unterbefehl anzuzeigen.",
+  "Run 'ollama-agent rag <subcommand> -h' for more details on a subcommand.": "Führen Sie 'ollama-agent rag <subcommand> -h' aus, um weitere Details zu einem Unterbefehl anzuzeigen.",
+  "Run 'ollama-agent skill <subcommand> -h' for more details on a subcommand.": "Führen Sie 'ollama-agent skill <subcommand> -h' aus, um weitere Details zu einem Unterbefehl anzuzeigen.",
+  "Run 'ollama-agent session <subcommand> -h' for more details on a subcommand.": "Führen Sie 'ollama-agent session <subcommand> -h' aus, um weitere Details zu einem Unterbefehl anzuzeigen.",
+  "Run 'ollama-agent mcp <subcommand> -h' for more details on a subcommand.": "Führen Sie 'ollama-agent mcp <subcommand> -h' aus, um weitere Details zu einem Unterbefehl anzuzeigen."
 }

--- a/ollama_agent/i18n/locales/es.json
+++ b/ollama_agent/i18n/locales/es.json
@@ -380,5 +380,11 @@
   "Invalid configuration or missing environment variables": "Configuración no válida o variables de entorno no encontradas",
   "Connection timed out ({timeout}s)": "Tiempo de espera de conexión agotado ({timeout}s)",
   "Error reading MCP configuration {path}: {exc}": "Error al leer la configuración de MCP {path}: {exc}",
-  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Subcomando mcp desconocido '{sub}'. Uso: /mcp [list]"
+  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Subcomando mcp desconocido '{sub}'. Uso: /mcp [list]",
+  "Run 'ollama-agent <command> -h' for more details on a specific command.": "Ejecuta 'ollama-agent <comando> -h' para más detalles sobre un comando específico.",
+  "Run 'ollama-agent task <subcommand> -h' for more details on a subcommand.": "Ejecuta 'ollama-agent task <subcomando> -h' para más detalles sobre un subcomando.",
+  "Run 'ollama-agent rag <subcommand> -h' for more details on a subcommand.": "Ejecuta 'ollama-agent rag <subcomando> -h' para más detalles sobre un subcomando.",
+  "Run 'ollama-agent skill <subcommand> -h' for more details on a subcommand.": "Ejecuta 'ollama-agent skill <subcomando> -h' para más detalles sobre un subcomando.",
+  "Run 'ollama-agent session <subcommand> -h' for more details on a subcommand.": "Ejecuta 'ollama-agent session <subcomando> -h' para más detalles sobre un subcomando.",
+  "Run 'ollama-agent mcp <subcommand> -h' for more details on a subcommand.": "Ejecuta 'ollama-agent mcp <subcomando> -h' para más detalles sobre un subcomando."
 }

--- a/ollama_agent/i18n/locales/fr.json
+++ b/ollama_agent/i18n/locales/fr.json
@@ -380,5 +380,11 @@
   "Invalid configuration or missing environment variables": "Configuration non valide ou variables d'environnement manquantes",
   "Connection timed out ({timeout}s)": "Délai de connexion dépassé ({timeout}s)",
   "Error reading MCP configuration {path}: {exc}": "Erreur lors de la lecture de la configuration MCP {path} : {exc}",
-  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Sous-commande mcp inconnue '{sub}'. Utilisation : /mcp [list]"
+  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Sous-commande mcp inconnue '{sub}'. Utilisation : /mcp [list]",
+  "Run 'ollama-agent <command> -h' for more details on a specific command.": "Exécutez 'ollama-agent <command> -h' pour plus de détails sur une commande spécifique.",
+  "Run 'ollama-agent task <subcommand> -h' for more details on a subcommand.": "Exécutez 'ollama-agent task <subcommand> -h' pour plus de détails sur une sous-commande.",
+  "Run 'ollama-agent rag <subcommand> -h' for more details on a subcommand.": "Exécutez 'ollama-agent rag <subcommand> -h' pour plus de détails sur une sous-commande.",
+  "Run 'ollama-agent skill <subcommand> -h' for more details on a subcommand.": "Exécutez 'ollama-agent skill <subcommand> -h' pour plus de détails sur une sous-commande.",
+  "Run 'ollama-agent session <subcommand> -h' for more details on a subcommand.": "Exécutez 'ollama-agent session <subcommand> -h' pour plus de détails sur une sous-commande.",
+  "Run 'ollama-agent mcp <subcommand> -h' for more details on a subcommand.": "Exécutez 'ollama-agent mcp <subcommand> -h' pour plus de détails sur une sous-commande."
 }

--- a/ollama_agent/i18n/locales/hi.json
+++ b/ollama_agent/i18n/locales/hi.json
@@ -380,5 +380,11 @@
   "Invalid configuration or missing environment variables": "अमान्य कॉन्फ़िगरेशन या अनुपलब्ध पर्यावरण चर",
   "Connection timed out ({timeout}s)": "कनेक्शन समय समाप्त ({timeout}s)",
   "Error reading MCP configuration {path}: {exc}": "MCP कॉन्फ़िगरेशन {path} पढ़ने में त्रुटि: {exc}",
-  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "अज्ञात mcp उप-कमांड '{sub}'। उपयोग: /mcp [list]"
+  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "अज्ञात mcp उप-कमांड '{sub}'। उपयोग: /mcp [list]",
+  "Run 'ollama-agent <command> -h' for more details on a specific command.": "किसी विशिष्ट कमांड पर अधिक विवरण देखने के लिए 'ollama-agent <command> -h' चलाएँ।",
+  "Run 'ollama-agent task <subcommand> -h' for more details on a subcommand.": "उप-कमांड पर अधिक विवरण देखने के लिए 'ollama-agent task <subcommand> -h' चलाएँ।",
+  "Run 'ollama-agent rag <subcommand> -h' for more details on a subcommand.": "उप-कमांड पर अधिक विवरण देखने के लिए 'ollama-agent rag <subcommand> -h' चलाएँ।",
+  "Run 'ollama-agent skill <subcommand> -h' for more details on a subcommand.": "उप-कमांड पर अधिक विवरण देखने के लिए 'ollama-agent skill <subcommand> -h' चलाएँ।",
+  "Run 'ollama-agent session <subcommand> -h' for more details on a subcommand.": "उप-कमांड पर अधिक विवरण देखने के लिए 'ollama-agent session <subcommand> -h' चलाएँ।",
+  "Run 'ollama-agent mcp <subcommand> -h' for more details on a subcommand.": "उप-कमांड पर अधिक विवरण देखने के लिए 'ollama-agent mcp <subcommand> -h' चलाएँ।"
 }

--- a/ollama_agent/i18n/locales/it.json
+++ b/ollama_agent/i18n/locales/it.json
@@ -380,5 +380,11 @@
   "Invalid configuration or missing environment variables": "Configurazione non valida o variabili di ambiente mancanti",
   "Connection timed out ({timeout}s)": "Timeout di connessione ({timeout}s)",
   "Error reading MCP configuration {path}: {exc}": "Errore durante la lettura della configurazione MCP {path}: {exc}",
-  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Sottocomando mcp sconosciuto '{sub}'. Utilizzo: /mcp [list]"
+  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Sottocomando mcp sconosciuto '{sub}'. Utilizzo: /mcp [list]",
+  "Run 'ollama-agent <command> -h' for more details on a specific command.": "Esegui 'ollama-agent <command> -h' per maggiori dettagli su un comando specifico.",
+  "Run 'ollama-agent task <subcommand> -h' for more details on a subcommand.": "Esegui 'ollama-agent task <subcommand> -h' per maggiori dettagli su un sottocomando.",
+  "Run 'ollama-agent rag <subcommand> -h' for more details on a subcommand.": "Esegui 'ollama-agent rag <subcommand> -h' per maggiori dettagli su un sottocomando.",
+  "Run 'ollama-agent skill <subcommand> -h' for more details on a subcommand.": "Esegui 'ollama-agent skill <subcommand> -h' per maggiori dettagli su un sottocomando.",
+  "Run 'ollama-agent session <subcommand> -h' for more details on a subcommand.": "Esegui 'ollama-agent session <subcommand> -h' per maggiori dettagli su un sottocomando.",
+  "Run 'ollama-agent mcp <subcommand> -h' for more details on a subcommand.": "Esegui 'ollama-agent mcp <subcommand> -h' per maggiori dettagli su un sottocomando."
 }

--- a/ollama_agent/i18n/locales/ja.json
+++ b/ollama_agent/i18n/locales/ja.json
@@ -380,5 +380,11 @@
   "Invalid configuration or missing environment variables": "無効な設定または環境変数が不足しています",
   "Connection timed out ({timeout}s)": "接続がタイムアウトしました ({timeout}秒)",
   "Error reading MCP configuration {path}: {exc}": "MCP 設定 {path} の読み込みエラー: {exc}",
-  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "不明な mcp サブコマンド '{sub}' です。使用法: /mcp [list]"
+  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "不明な mcp サブコマンド '{sub}' です。使用法: /mcp [list]",
+  "Run 'ollama-agent <command> -h' for more details on a specific command.": "特定のコマンドの詳細ヘルプを表示するには 'ollama-agent <command> -h' を実行してください。",
+  "Run 'ollama-agent task <subcommand> -h' for more details on a subcommand.": "サブコマンドの詳細を表示するには 'ollama-agent task <subcommand> -h' を実行してください。",
+  "Run 'ollama-agent rag <subcommand> -h' for more details on a subcommand.": "サブコマンドの詳細を表示するには 'ollama-agent rag <subcommand> -h' を実行してください。",
+  "Run 'ollama-agent skill <subcommand> -h' for more details on a subcommand.": "サブコマンドの詳細を表示するには 'ollama-agent skill <subcommand> -h' を実行してください。",
+  "Run 'ollama-agent session <subcommand> -h' for more details on a subcommand.": "サブコマンドの詳細を表示するには 'ollama-agent session <subcommand> -h' を実行してください。",
+  "Run 'ollama-agent mcp <subcommand> -h' for more details on a subcommand.": "サブコマンドの詳細を表示するには 'ollama-agent mcp <subcommand> -h' を実行してください。"
 }

--- a/ollama_agent/i18n/locales/pt.json
+++ b/ollama_agent/i18n/locales/pt.json
@@ -380,5 +380,11 @@
   "Invalid configuration or missing environment variables": "Configuração inválida ou variáveis de ambiente ausentes",
   "Connection timed out ({timeout}s)": "Tempo limite de conexão esgotado ({timeout}s)",
   "Error reading MCP configuration {path}: {exc}": "Erro ao ler a configuração MCP {path}: {exc}",
-  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Subcomando mcp desconhecido '{sub}'. Uso: /mcp [list]"
+  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Subcomando mcp desconhecido '{sub}'. Uso: /mcp [list]",
+  "Run 'ollama-agent <command> -h' for more details on a specific command.": "Execute 'ollama-agent <command> -h' para mais detalhes sobre um comando específico.",
+  "Run 'ollama-agent task <subcommand> -h' for more details on a subcommand.": "Execute 'ollama-agent task <subcommand> -h' para mais detalhes sobre um subcomando.",
+  "Run 'ollama-agent rag <subcommand> -h' for more details on a subcommand.": "Execute 'ollama-agent rag <subcommand> -h' para mais detalhes sobre um subcomando.",
+  "Run 'ollama-agent skill <subcommand> -h' for more details on a subcommand.": "Execute 'ollama-agent skill <subcommand> -h' para mais detalhes sobre um subcomando.",
+  "Run 'ollama-agent session <subcommand> -h' for more details on a subcommand.": "Execute 'ollama-agent session <subcommand> -h' para mais detalhes sobre um subcomando.",
+  "Run 'ollama-agent mcp <subcommand> -h' for more details on a subcommand.": "Execute 'ollama-agent mcp <subcommand> -h' para mais detalhes sobre um subcomando."
 }

--- a/ollama_agent/i18n/locales/ru.json
+++ b/ollama_agent/i18n/locales/ru.json
@@ -380,5 +380,11 @@
   "Invalid configuration or missing environment variables": "Неверная конфигурация или отсутствуют переменные окружения",
   "Connection timed out ({timeout}s)": "Время ожидания подключения истекло ({timeout}с)",
   "Error reading MCP configuration {path}: {exc}": "Ошибка чтения конфигурации MCP {path}: {exc}",
-  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Неизвестная подкоманда mcp '{sub}'. Использование: /mcp [list]"
+  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "Неизвестная подкоманда mcp '{sub}'. Использование: /mcp [list]",
+  "Run 'ollama-agent <command> -h' for more details on a specific command.": "Запустите 'ollama-agent <command> -h' для получения подробной информации о команде.",
+  "Run 'ollama-agent task <subcommand> -h' for more details on a subcommand.": "Запустите 'ollama-agent task <subcommand> -h' для получения подробной информации о подкоманде.",
+  "Run 'ollama-agent rag <subcommand> -h' for more details on a subcommand.": "Запустите 'ollama-agent rag <subcommand> -h' для получения подробной информации о подкоманде.",
+  "Run 'ollama-agent skill <subcommand> -h' for more details on a subcommand.": "Запустите 'ollama-agent skill <subcommand> -h' для получения подробной информации о подкоманде.",
+  "Run 'ollama-agent session <subcommand> -h' for more details on a subcommand.": "Запустите 'ollama-agent session <subcommand> -h' для получения подробной информации о подкоманде.",
+  "Run 'ollama-agent mcp <subcommand> -h' for more details on a subcommand.": "Запустите 'ollama-agent mcp <subcommand> -h' для получения подробной информации о подкоманде."
 }

--- a/ollama_agent/i18n/locales/zh.json
+++ b/ollama_agent/i18n/locales/zh.json
@@ -380,5 +380,11 @@
   "Invalid configuration or missing environment variables": "配置无效或缺少环境变量",
   "Connection timed out ({timeout}s)": "连接超时 ({timeout}秒)",
   "Error reading MCP configuration {path}: {exc}": "读取 MCP 配置文件 {path} 失败: {exc}",
-  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "未知的 mcp 子命令 '{sub}'。用法: /mcp [list]"
+  "Unknown mcp subcommand '{sub}'. Usage: /mcp [list]": "未知的 mcp 子命令 '{sub}'。用法: /mcp [list]",
+  "Run 'ollama-agent <command> -h' for more details on a specific command.": "运行 'ollama-agent <command> -h' 查看特定命令的详细帮助。",
+  "Run 'ollama-agent task <subcommand> -h' for more details on a subcommand.": "运行 'ollama-agent task <subcommand> -h' 查看子命令的详细帮助。",
+  "Run 'ollama-agent rag <subcommand> -h' for more details on a subcommand.": "运行 'ollama-agent rag <subcommand> -h' 查看子命令的详细帮助。",
+  "Run 'ollama-agent skill <subcommand> -h' for more details on a subcommand.": "运行 'ollama-agent skill <subcommand> -h' 查看子命令的详细帮助。",
+  "Run 'ollama-agent session <subcommand> -h' for more details on a subcommand.": "运行 'ollama-agent session <subcommand> -h' 查看子命令的详细帮助。",
+  "Run 'ollama-agent mcp <subcommand> -h' for more details on a subcommand.": "运行 'ollama-agent mcp <subcommand> -h' 查看子命令的详细帮助。"
 }

--- a/ollama_agent/interfaces/cli.py
+++ b/ollama_agent/interfaces/cli.py
@@ -78,20 +78,21 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _add_subparser(
-    subparsers: argparse._SubParsersAction, name: str, help_msg: str
-) -> argparse.ArgumentParser:
-    """Helper to add a subparser."""
-    return subparsers.add_parser(name, help=help_msg)
-
-
-def _add_task_subcommands(parser: argparse.ArgumentParser) -> None:
-    subparsers = parser.add_subparsers(dest="command", help=_("Task management commands"))
+def _add_subcommands(parser: argparse.ArgumentParser) -> None:
+    subparsers = parser.add_subparsers(dest="command")
 
     # Task commands
-    _add_subparser(subparsers, "task-list", _("List all saved tasks"))
+    task_parser = subparsers.add_parser(
+        "task",
+        help=_("Manage saved tasks"),
+        description=_("Manage saved tasks"),
+        epilog=_("Run 'ollama-agent task <subcommand> -h' for more details on a subcommand."),
+    )
+    task_sub = task_parser.add_subparsers(dest="subcommand", required=True)
 
-    task_create = _add_subparser(subparsers, "task-create", _("Create a new task"))
+    task_sub.add_parser("list", help=_("List all saved tasks"))
+
+    task_create = task_sub.add_parser("create", help=_("Create a new task"))
     task_create.add_argument("task_id", type=str, help=_("Task ID (filename stem)"))
     task_create.add_argument("--title", type=str, required=True, help=_("Task title"))
     task_create.add_argument(
@@ -119,7 +120,7 @@ def _add_task_subcommands(parser: argparse.ArgumentParser) -> None:
         "--force", action="store_true", help=_("Overwrite task if it already exists")
     )
 
-    task_run = _add_subparser(subparsers, "task-run", _("Execute a saved task"))
+    task_run = task_sub.add_parser("run", help=_("Execute a saved task"))
     task_run.add_argument("task_id", type=str, help=_("Task ID or prefix to execute"))
     task_run.add_argument(
         "-y",
@@ -129,21 +130,29 @@ def _add_task_subcommands(parser: argparse.ArgumentParser) -> None:
         help=_("Enable YOLO mode (bypasses all tool execution confirmation prompts)"),
     )
 
-    task_delete = _add_subparser(subparsers, "task-delete", _("Delete a saved task"))
+    task_delete = task_sub.add_parser("delete", help=_("Delete a saved task"))
     task_delete.add_argument("task_id", type=str, help=_("Task ID or prefix to delete"))
 
-    # RAG subcommands
-    _add_subparser(subparsers, "rag-list", _("List all RAG databases"))
+    # RAG commands
+    rag_parser = subparsers.add_parser(
+        "rag",
+        help=_("Manage RAG databases"),
+        description=_("Manage RAG databases"),
+        epilog=_("Run 'ollama-agent rag <subcommand> -h' for more details on a subcommand."),
+    )
+    rag_sub = rag_parser.add_subparsers(dest="subcommand", required=True)
 
-    rag_create = _add_subparser(subparsers, "rag-create", _("Create a new RAG database"))
+    rag_sub.add_parser("list", help=_("List all RAG databases"))
+
+    rag_create = rag_sub.add_parser("create", help=_("Create a new RAG database"))
     rag_create.add_argument("name", type=str, help=_("Name for the new RAG database"))
 
-    rag_delete = _add_subparser(subparsers, "rag-delete", _("Delete a RAG database"))
+    rag_delete = rag_sub.add_parser("delete", help=_("Delete a RAG database"))
     rag_delete.add_argument(
         "name", type=str, help=_("Name or prefix of the database to delete")
     )
 
-    rag_add = _add_subparser(subparsers, "rag-add", _("Add file(s) to a RAG database"))
+    rag_add = rag_sub.add_parser("add", help=_("Add file(s) to a RAG database"))
     rag_add.add_argument("database", type=str, help=_("Name of the RAG database"))
     rag_add.add_argument("path", type=str, help=_("File or directory path to add"))
     rag_add.add_argument(
@@ -152,13 +161,21 @@ def _add_task_subcommands(parser: argparse.ArgumentParser) -> None:
         help=_("Treat path as directory and add all files recursively"),
     )
 
-    # Skill subcommands
-    _add_subparser(subparsers, "skill-list", _("List all skills"))
+    # Skill commands
+    skill_parser = subparsers.add_parser(
+        "skill",
+        help=_("Manage skills"),
+        description=_("Manage skills"),
+        epilog=_("Run 'ollama-agent skill <subcommand> -h' for more details on a subcommand."),
+    )
+    skill_sub = skill_parser.add_subparsers(dest="subcommand", required=True)
 
-    skill_show = _add_subparser(subparsers, "skill-show", _("Show skill details"))
+    skill_sub.add_parser("list", help=_("List all skills"))
+
+    skill_show = skill_sub.add_parser("show", help=_("Show skill details"))
     skill_show.add_argument("skill_id", type=str, help=_("Skill ID or prefix"))
 
-    skill_create = _add_subparser(subparsers, "skill-create", _("Create a new skill"))
+    skill_create = skill_sub.add_parser("create", help=_("Create a new skill"))
     skill_create.add_argument("skill_id", type=str, help=_("Skill ID (directory name)"))
     skill_create.add_argument("--name", type=str, required=True, help=_("Skill name"))
     skill_create.add_argument(
@@ -174,36 +191,53 @@ def _add_task_subcommands(parser: argparse.ArgumentParser) -> None:
         "--force", action="store_true", help=_("Overwrite skill if it already exists")
     )
 
-    skill_delete = _add_subparser(subparsers, "skill-delete", _("Delete a skill"))
+    skill_delete = skill_sub.add_parser("delete", help=_("Delete a skill"))
     skill_delete.add_argument("skill_id", type=str, help=_("Skill ID or prefix to delete"))
 
-    # Session subcommands
-    _add_subparser(subparsers, "session-list", _("List all past chat sessions"))
+    # Session commands
+    session_parser = subparsers.add_parser(
+        "session",
+        help=_("Manage chat sessions"),
+        description=_("Manage chat sessions"),
+        epilog=_("Run 'ollama-agent session <subcommand> -h' for more details on a subcommand."),
+    )
+    session_sub = session_parser.add_subparsers(dest="subcommand", required=True)
 
-    session_search = _add_subparser(
-        subparsers, "session-search", _("Search past chat sessions by query keyword")
+    session_sub.add_parser("list", help=_("List all past chat sessions"))
+
+    session_search = session_sub.add_parser(
+        "search", help=_("Search past chat sessions by query keyword")
     )
     session_search.add_argument("query", type=str, help=_("Search query string"))
 
-    session_del = _add_subparser(subparsers, "session-delete", _("Delete a chat session from history"))
+    session_del = session_sub.add_parser("delete", help=_("Delete a chat session from history"))
     session_del.add_argument("session_id", type=str, help=_("Session ID or prefix to delete"))
 
-    session_exp = _add_subparser(subparsers, "session-export", _("Export a chat session to Markdown"))
+    session_exp = session_sub.add_parser("export", help=_("Export a chat session to Markdown"))
     session_exp.add_argument("session_id", type=str, help=_("Session ID or prefix to export"))
     session_exp.add_argument("--output", "-o", type=str, required=False, help=_("Target markdown file path"))
 
-    # MCP subcommands
-    _add_subparser(subparsers, "mcp-list", _("List configured MCP servers and check their status"))
+    # MCP commands
+    mcp_parser = subparsers.add_parser(
+        "mcp",
+        help=_("Manage and check MCP servers"),
+        description=_("Manage and check MCP servers"),
+        epilog=_("Run 'ollama-agent mcp <subcommand> -h' for more details on a subcommand."),
+    )
+    mcp_sub = mcp_parser.add_subparsers(dest="subcommand", required=True)
+
+    mcp_sub.add_parser("list", help=_("List configured MCP servers and check their status"))
 
 
 def create_argument_parser() -> argparse.ArgumentParser:
     """Create and configure argument parser."""
     parser = argparse.ArgumentParser(
-        description=_("Ollama Agent - AI agent to interact with local models")
+        description=_("Ollama Agent - AI agent to interact with local models"),
+        epilog=_("Run 'ollama-agent <command> -h' for more details on a specific command."),
     )
 
     _add_common_args(parser)
-    _add_task_subcommands(parser)
+    _add_subcommands(parser)
 
     return parser
 
@@ -217,23 +251,26 @@ def handle_cli_commands(
     skills_ctx = SkillsContext(skill_manager=SkillManager())
 
     cmd = args.command
-    if cmd == "session-export":
-        args._runtime = AgentRuntime(settings=settings)
-    handlers = build_cli_handlers(
-        args,
-        task_ctx=ctx,
-        rag_ctx=rag_ctx,
-        skills_ctx=skills_ctx,
-        settings=settings,
-    )
-    if cmd in handlers:
-        try:
-            result = handlers[cmd]()
-            if inspect.isawaitable(result):
-                asyncio.run(result)  # type: ignore[arg-type]
-        except (SkillError, TaskError, RAGError):
-            raise SystemExit(1)
-        return True
+    subcmd = getattr(args, "subcommand", None)
+    if cmd and subcmd:
+        if cmd == "session" and subcmd == "export":
+            args._runtime = AgentRuntime(settings=settings)
+        handlers = build_cli_handlers(
+            args,
+            task_ctx=ctx,
+            rag_ctx=rag_ctx,
+            skills_ctx=skills_ctx,
+            settings=settings,
+        )
+        handler_key = (cmd, subcmd)
+        if handler_key in handlers:
+            try:
+                result = handlers[handler_key]()
+                if inspect.isawaitable(result):
+                    asyncio.run(result)  # type: ignore[arg-type]
+            except (SkillError, TaskError, RAGError):
+                raise SystemExit(1)
+            return True
 
     if args.prompt:
         runtime = AgentRuntime(settings=settings, yolo_mode=args.yolo)

--- a/ollama_agent/interfaces/dispatch.py
+++ b/ollama_agent/interfaces/dispatch.py
@@ -92,7 +92,7 @@ def build_cli_handlers(
     rag_ctx: RAGContext,
     skills_ctx: SkillsContext,
     settings: Settings | None = None,
-) -> dict[str, CLIHandler]:
+) -> dict[tuple[str, str], CLIHandler]:
     """Map parsed CLI subcommands to their synchronous or async handler functions."""
 
     async def rag_add() -> None:
@@ -103,10 +103,10 @@ def build_cli_handlers(
         await add_rag_file(rag_ctx, args.path)
 
     return {
-        "task-list": lambda: list_tasks(task_ctx),
-        "task-delete": lambda: delete_task(task_ctx, args.task_id),
-        "task-run": lambda: run_task(task_ctx, args.task_id, yolo=args.yolo),
-        "task-create": lambda: create_task(
+        ("task", "list"): lambda: list_tasks(task_ctx),
+        ("task", "delete"): lambda: delete_task(task_ctx, args.task_id),
+        ("task", "run"): lambda: run_task(task_ctx, args.task_id, yolo=args.yolo),
+        ("task", "create"): lambda: create_task(
             task_ctx,
             args.task_id,
             title=args.title,
@@ -115,14 +115,14 @@ def build_cli_handlers(
             reasoning_effort=(args.task_effort or args.effort),
             force=args.force,
         ),
-        "rag-list": lambda: list_rag_databases(rag_ctx),
-        "rag-create": lambda: create_rag_database(rag_ctx, args.name),
-        "rag-delete": lambda: delete_rag_database(rag_ctx, args.name),
-        "rag-add": rag_add,
-        "skill-list": lambda: list_skills(skills_ctx),
-        "skill-show": lambda: show_skill(skills_ctx, args.skill_id),
-        "skill-delete": lambda: delete_skill(skills_ctx, args.skill_id),
-        "skill-create": lambda: create_skill(
+        ("rag", "list"): lambda: list_rag_databases(rag_ctx),
+        ("rag", "create"): lambda: create_rag_database(rag_ctx, args.name),
+        ("rag", "delete"): lambda: delete_rag_database(rag_ctx, args.name),
+        ("rag", "add"): rag_add,
+        ("skill", "list"): lambda: list_skills(skills_ctx),
+        ("skill", "show"): lambda: show_skill(skills_ctx, args.skill_id),
+        ("skill", "delete"): lambda: delete_skill(skills_ctx, args.skill_id),
+        ("skill", "create"): lambda: create_skill(
             skills_ctx,
             args.skill_id,
             name=args.name,
@@ -130,16 +130,16 @@ def build_cli_handlers(
             instructions=args.instructions,
             force=args.force,
         ),
-        "session-list": lambda: list_sessions(Console()),
-        "session-search": lambda: search_sessions(Console(), args.query),
-        "session-delete": lambda: delete_session(Console(), args.session_id),
-        "session-export": lambda: _cli_export_session(
+        ("session", "list"): lambda: list_sessions(Console()),
+        ("session", "search"): lambda: search_sessions(Console(), args.query),
+        ("session", "delete"): lambda: delete_session(Console(), args.session_id),
+        ("session", "export"): lambda: _cli_export_session(
             Console(),
             args._runtime,
             args.session_id,
             output_path=args.output,
         ),
-        "mcp-list": lambda: list_mcp_servers(
+        ("mcp", "list"): lambda: list_mcp_servers(
             Console(),
             settings=settings,
         ),

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -48,32 +48,32 @@ class TestDispatchAndCLI(unittest.TestCase):
 
     def test_task_run_yolo_flag_parsing(self) -> None:
         parser = create_argument_parser()
-        args1 = parser.parse_args(["task-run", "my-task", "-y"])
+        args1 = parser.parse_args(["task", "run", "my-task", "-y"])
         self.assertEqual(args1.task_id, "my-task")
         self.assertTrue(args1.yolo)
 
-        args2 = parser.parse_args(["-y", "task-run", "my-task"])
+        args2 = parser.parse_args(["-y", "task", "run", "my-task"])
         self.assertEqual(args2.task_id, "my-task")
         self.assertTrue(args2.yolo)
 
-        args3 = parser.parse_args(["task-run", "my-task"])
+        args3 = parser.parse_args(["task", "run", "my-task"])
         self.assertEqual(args3.task_id, "my-task")
         self.assertFalse(args3.yolo)
 
     def test_build_cli_handlers_registry(self) -> None:
         parser = create_argument_parser()
-        args = parser.parse_args(["task-list"])
+        args = parser.parse_args(["task", "list"])
         handlers = build_cli_handlers(
             args,
             task_ctx=CLIContext(console=Console(file=io.StringIO())),
             rag_ctx=RAGContext(rag_manager=RAGManager(RAGSettings()), console=Console(file=io.StringIO())),
             skills_ctx=SkillsContext(console=Console(file=io.StringIO())),
         )
-        self.assertIn("task-list", handlers)
-        self.assertIn("task-create", handlers)
-        self.assertIn("rag-list", handlers)
-        self.assertIn("skill-list", handlers)
-        self.assertIn("mcp-list", handlers)
+        self.assertIn(("task", "list"), handlers)
+        self.assertIn(("task", "create"), handlers)
+        self.assertIn(("rag", "list"), handlers)
+        self.assertIn(("skill", "list"), handlers)
+        self.assertIn(("mcp", "list"), handlers)
 
     def test_build_repl_handlers_registry(self) -> None:
         async def dummy_async_str(_: str) -> None:
@@ -122,7 +122,7 @@ class TestDispatchAndCLI(unittest.TestCase):
             mock_print.assert_called_once_with("Reset successful")
 
     def test_main_cli_commands_handled(self) -> None:
-        with patch("sys.argv", ["ollama-agent", "task-list"]), \
+        with patch("sys.argv", ["ollama-agent", "task", "list"]), \
              patch("ollama_agent.main.load_settings", return_value=Settings()), \
              patch("ollama_agent.main.handle_cli_commands", return_value=True) as mock_handle:
             main()
@@ -157,7 +157,7 @@ class TestDispatchAndCLI(unittest.TestCase):
 
     def test_cli_rag_add_file_and_directory(self) -> None:
         parser = create_argument_parser()
-        args_file = parser.parse_args(["rag-add", "docs_db", "file.md"])
+        args_file = parser.parse_args(["rag", "add", "docs_db", "file.md"])
         mock_load = MagicMock()
         mock_add_file = AsyncMock()
         mock_add_dir = AsyncMock()
@@ -171,7 +171,7 @@ class TestDispatchAndCLI(unittest.TestCase):
                 rag_ctx=RAGContext(rag_manager=RAGManager(RAGSettings()), console=Console(file=io.StringIO())),
                 skills_ctx=SkillsContext(console=Console(file=io.StringIO())),
             )
-            asyncio.run(handlers["rag-add"]())
+            asyncio.run(handlers[("rag", "add")]())
             mock_load.assert_called_once()
             mock_add_file.assert_called_once()
             mock_add_dir.assert_not_called()
@@ -180,7 +180,7 @@ class TestDispatchAndCLI(unittest.TestCase):
         mock_add_file.reset_mock()
         mock_add_dir.reset_mock()
 
-        args_dir = parser.parse_args(["rag-add", "docs_db", "./docs", "--dir"])
+        args_dir = parser.parse_args(["rag", "add", "docs_db", "./docs", "--dir"])
         with patch("ollama_agent.interfaces.dispatch.load_rag_database", mock_load), \
              patch("ollama_agent.interfaces.dispatch.add_rag_file", mock_add_file), \
              patch("ollama_agent.interfaces.dispatch.add_rag_directory", mock_add_dir):
@@ -190,14 +190,14 @@ class TestDispatchAndCLI(unittest.TestCase):
                 rag_ctx=RAGContext(rag_manager=RAGManager(RAGSettings()), console=Console(file=io.StringIO())),
                 skills_ctx=SkillsContext(console=Console(file=io.StringIO())),
             )
-            asyncio.run(handlers["rag-add"]())
+            asyncio.run(handlers[("rag", "add")]())
             mock_load.assert_called_once()
             mock_add_file.assert_not_called()
             mock_add_dir.assert_called_once()
 
     def test_cli_session_export(self) -> None:
         parser = create_argument_parser()
-        args = parser.parse_args(["session-export", "sess-123", "-o", "export.md"])
+        args = parser.parse_args(["session", "export", "sess-123", "-o", "export.md"])
         args._runtime = AsyncMock()
 
         with patch("ollama_agent.interfaces.dispatch.export_session", AsyncMock()) as mock_export:
@@ -207,7 +207,7 @@ class TestDispatchAndCLI(unittest.TestCase):
                 rag_ctx=RAGContext(rag_manager=RAGManager(RAGSettings()), console=Console(file=io.StringIO())),
                 skills_ctx=SkillsContext(console=Console(file=io.StringIO())),
             )
-            asyncio.run(handlers["session-export"]())
+            asyncio.run(handlers[("session", "export")]())
             mock_export.assert_called_once()
 
 

--- a/tests/test_interfaces_commands.py
+++ b/tests/test_interfaces_commands.py
@@ -406,7 +406,7 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
             mock_del_sess.assert_called_once_with(console, "session-1234")
 
     def test_handle_cli_commands_subcommand(self) -> None:
-        args = argparse.Namespace(command="task-list", prompt=None, yolo=False, rag=None)
+        args = argparse.Namespace(command="task", subcommand="list", prompt=None, yolo=False, rag=None)
         settings = Settings()
         with patch("ollama_agent.interfaces.dispatch.list_tasks") as mock_list:
             handled = handle_cli_commands(args, settings)
@@ -414,7 +414,7 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
             mock_list.assert_called_once()
 
     def test_handle_cli_commands_session_list(self) -> None:
-        args = argparse.Namespace(command="session-list", prompt=None, yolo=False, rag=None)
+        args = argparse.Namespace(command="session", subcommand="list", prompt=None, yolo=False, rag=None)
         settings = Settings()
         with patch("ollama_agent.interfaces.dispatch.list_sessions") as mock_list:
             handled = handle_cli_commands(args, settings)
@@ -422,7 +422,7 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
             mock_list.assert_called_once()
 
     def test_handle_cli_commands_session_search(self) -> None:
-        args = argparse.Namespace(command="session-search", query="fastapi", prompt=None, yolo=False, rag=None)
+        args = argparse.Namespace(command="session", subcommand="search", query="fastapi", prompt=None, yolo=False, rag=None)
         settings = Settings()
         with patch("ollama_agent.interfaces.dispatch.search_sessions") as mock_search:
             handled = handle_cli_commands(args, settings)
@@ -430,7 +430,7 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
             mock_search.assert_called_once()
 
     def test_handle_cli_commands_session_delete(self) -> None:
-        args = argparse.Namespace(command="session-delete", session_id="session-123", prompt=None, yolo=False, rag=None)
+        args = argparse.Namespace(command="session", subcommand="delete", session_id="session-123", prompt=None, yolo=False, rag=None)
         settings = Settings()
         with patch("ollama_agent.interfaces.dispatch.delete_session") as mock_del:
             handled = handle_cli_commands(args, settings)


### PR DESCRIPTION
## Summary
- Refactored CLI subcommands from flat hyphenated commands (e.g. `task-list`, `skill-list`, `rag-list`, `session-list`, `mcp-list`) to standard nested positional arguments (`task list`, `skill list`, `rag list`, `session list`, `mcp list`).
- Added clear epilog and subcommand documentation for all commands across all 9 supported locales.
- Updated dispatch handlers and all test cases.
- Synchronized documentation in README.md and `docs/`.