### PR TITLE
feat(models): support 'max' context window with automatic model metadata detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ subagents: []
 | `model.min_p` | `float` | *(dynamic)* | Optional minimum probability threshold override (0.0 default if unset). |
 | `model.presence_penalty` | `float` | *(dynamic)* | Optional presence penalty override (0.0 default if unset). |
 | `model.repeat_penalty` | `float` | *(dynamic)* | Optional repetition penalty override (1.1 engine default; alias: `repetition_penalty`). |
-| `model.context_window` | `int` | `10000` | Fallback context window token limit (`num_ctx`). |
+| `model.context_window` | `int` \| `str` | `10000` | Context window token limit (`num_ctx`), or `'max'` to auto-detect model maximum. |
 | `model.reasoning_effort` | `str` | `medium` | Default reasoning effort (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`). |
 | `runtime.allow_traversal` | `bool` | `false` | If true, permits filesystem operations outside project working directory. |
 | `runtime.builtin_tool_timeout` | `int` | `30` | Execution timeout in seconds for tool and shell commands. |
@@ -742,10 +742,11 @@ flowchart TD
 
 The effective context window (`num_ctx`) is resolved automatically in the following hierarchy:
 
-1. `model.context_window` defined in `settings.yaml` (if configured > 0).
-2. Structured metadata from `ollama show <model>` (e.g. `llama.context_length`, `qwen2.context_length`).
-3. Modelfile parameter regex (`PARAMETER num_ctx <size>`) from `ollama show <model>`.
-4. If unresolved, the agent halts with a clear configuration prompt.
+1. `model.context_window` defined in `settings.yaml` (if explicitly configured as a positive number > 0).
+2. Dynamic resolution when set to `'max'` or omitted:
+   - Structured metadata from `ollama show <model>` (e.g. `llama.context_length`, `qwen2.context_length`).
+   - Modelfile parameter regex (`PARAMETER num_ctx <size>`) from `ollama show <model>`.
+3. If unresolved, the agent halts with a clear configuration prompt.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,7 @@ subagents:
 | `model.min_p` | `float` | *(dynamic)* | Optional minimum probability threshold override (0.0 default if unset). |
 | `model.presence_penalty` | `float` | *(dynamic)* | Optional presence penalty override (0.0 default if unset). |
 | `model.repeat_penalty` | `float` | *(dynamic)* | Optional repetition penalty override (1.1 engine default; alias: `repetition_penalty`). |
-| `model.context_window` | `int` | `10000` | Fallback context window token limit (`num_ctx`). |
+| `model.context_window` | `int` \| `str` | `10000` | Context window token limit (`num_ctx`), or `'max'` to auto-detect model maximum. |
 | `model.reasoning_effort` | `str` | `medium` | Default reasoning effort (`low`, `medium`, `high`, `xhigh`, `disabled`, `hide`, `enabled`). |
 | `runtime.allow_traversal` | `bool` | `false` | If true, permits filesystem operations outside project working directory. |
 | `runtime.builtin_tool_timeout` | `int` | `30` | Execution timeout in seconds for tool and shell commands. |
@@ -144,9 +144,9 @@ To guarantee optimal context utilization without exceeding model memory boundari
 
 ```mermaid
 flowchart TD
-    A[Start Context Resolution] --> B{Explicit Config Override?}
-    B -- Yes (`model.context_window` > 0) --> C[Use Configured Value]
-    B -- No / Unset --> D[Fetch Model Metadata via `ollama.show()`]
+    A[Start Context Resolution] --> B{Configured Value?}
+    B -- Explicit int > 0 --> C[Use Configured Value]
+    B -- 'max' / Unset --> D[Fetch Model Metadata via `ollama.show()`]
     D --> E{Structured `model_info` Key?}
     E -- Found `*.context_length` --> F[Use `context_length` Metadata]
     E -- Not Found --> G{Modelfile / Parameter `num_ctx`?}
@@ -154,10 +154,11 @@ flowchart TD
     G -- Not Found --> I[Raise `ModelContextWindowError`]
 ```
 
-1. **Explicit Configuration Override**: If `model.context_window` in `settings.yaml` (or CLI argument) is explicitly defined (> 0), its value is used directly.
-2. **Structured Model Metadata (`model_info`)**: Queries Ollama's `AsyncClient.show()` endpoint for modern model metadata keys ending in `.context_length` (e.g., `llama.context_length`, `qwen2.context_length`).
-3. **Modelfile Parameter Parsing**: Scans raw Modelfile `parameters` or string fields using regex matching (`^\s*(?:PARAMETER\s+)?num_ctx\s+(\d+)\s*$`) to extract declared `num_ctx` values.
-4. **Error Handling**: If resolution fails across all stages, `ollama-agent` halts startup and raises a `ModelContextWindowError`, prompting the user to specify `context_window` in `settings.yaml`.
+1. **Explicit Numeric Configuration Override**: If `model.context_window` in `settings.yaml` (or CLI argument) is explicitly defined (> 0), its value is used directly.
+2. **Dynamic Maximum Resolution (`'max'` or Unset)**: When configured as `'max'` (or omitted), `ollama-agent` fetches model metadata from Ollama (`ollama.show()`) to use the maximum context length supported by the model:
+   - **Structured Model Metadata (`model_info`)**: Queries modern model metadata keys ending in `.context_length` (e.g., `llama.context_length`, `qwen2.context_length`).
+   - **Modelfile Parameter Parsing**: Scans raw Modelfile `parameters` or string fields using regex matching (`^\s*(?:PARAMETER\s+)?num_ctx\s+(\d+)\s*$`) to extract declared `num_ctx` values.
+3. **Error Handling**: If resolution fails across all stages, `ollama-agent` halts startup and raises a `ModelContextWindowError`, prompting the user to specify `context_window` in `settings.yaml`.
 
 ---
 

--- a/docs/mcp_subagents.md
+++ b/docs/mcp_subagents.md
@@ -161,7 +161,7 @@ subagents:
 | `description` | `string` | *(Required)* | Detailed description of when and how the main agent should delegate to this subagent. |
 | `system_prompt` | `string` | `""` | System prompt instructions. If omitted, defaults to `description`. OS environment info is appended automatically. |
 | `model` | `string` | `""` | Ollama model name. If omitted or empty, inherits the main agent's configured model. |
-| `context_window` | `integer` | `0` | Context window size (`num_ctx`). If `0` or omitted, inherits the main agent's setting. |
+| `context_window` | `integer` \| `string` | `0` | Context window size (`num_ctx`), or `'max'` for maximum model context. If `0` or omitted, inherits the main agent's setting. |
 | `mcp_servers` | `array` | `[]` | Dedicated MCP server definitions attached exclusively to this subagent. |
 
 #### Subagent MCP Server Fields (`mcp_servers`)

--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -89,6 +89,7 @@ class AgentRuntime:
     yolo_mode: bool = field(default=False)
     auto_approved_tools: set[str] = field(default_factory=set)
     last_context_tokens: int = field(default=0, init=False)
+    effective_context_window: int = field(default=0, init=False)
     effective_model_params: dict[str, tuple[Any, str]] = field(default_factory=dict, init=False)
     graph: Any = field(default=None, init=False, repr=False)
     _backend: Any = field(default=None, init=False, repr=False)
@@ -128,6 +129,7 @@ class AgentRuntime:
             repeat_penalty=ms.repeat_penalty,
             warn_callback=_log.warning,
         )
+        self.effective_context_window = getattr(model, "num_ctx", 0)
         self.effective_model_params = model.effective_params
 
         # Backend: CWD for shell + APP_DIR for agent files (memory, etc.)

--- a/ollama_agent/core/models.py
+++ b/ollama_agent/core/models.py
@@ -54,7 +54,7 @@ def _model_context_length(model_info: dict[str, Any]) -> int | None:
     values = [
         int(v)
         for k, v in model_info.items()
-        if str(k).endswith(".context_length") and str(v).isdigit()
+        if str(k).endswith("context_length") and str(v).isdigit()
     ]
     return max(values, default=None)
 
@@ -88,10 +88,21 @@ async def model_supports_thinking(model: str, base_url: str) -> bool:
 
 async def resolve_context_window(
     model: str,
-    context_window: int | None,
+    context_window: int | str | None,
     base_url: str,
 ) -> int:
     """Resolve the effective context window for a model."""
+    if isinstance(context_window, str):
+        cleaned = context_window.strip().lower()
+        if cleaned == "max":
+            context_window = None
+        elif cleaned.isdigit():
+            context_window = int(cleaned)
+        else:
+            raise ModelContextWindowError(
+                _("Invalid context_window '{value}'. Expected a positive integer or 'max'.", value=context_window)
+            )
+
     if context_window is not None:
         if context_window <= 0:
             raise ModelContextWindowError(_("context_window must be greater than zero."))
@@ -100,7 +111,7 @@ async def resolve_context_window(
     response = await _show_model(model, base_url)
 
     # 1. Structured info is the most reliable (modern Ollama)
-    model_info = getattr(response, "model_info", None)
+    model_info = getattr(response, "model_info", None) or getattr(response, "modelinfo", None)
     if isinstance(model_info, dict) and (resolved := _model_context_length(model_info)):
         return resolved
 
@@ -242,7 +253,7 @@ async def create_ollama_chat_model(
     *,
     model: str,
     base_url: str,
-    context_window: int | None,
+    context_window: int | str | None,
     reasoning_effort: ReasoningEffortValue,
     temperature: float | None = None,
     top_p: float | None = None,

--- a/ollama_agent/i18n/locales/de.json
+++ b/ollama_agent/i18n/locales/de.json
@@ -295,6 +295,7 @@
   "Failed to fetch metadata for '{model}': {exc}": "Metadaten für '{model}' konnten nicht abgerufen werden: {exc}",
   "Model '{model}' does not support tools.": "Modell '{model}' unterstützt keine Tools.",
   "context_window must be greater than zero.": "context_window muss größer als Null sein.",
+  "Invalid context_window '{value}'. Expected a positive integer or 'max'.": "Ungültiges context_window '{value}'. Erwartet wurde eine positive Ganzzahl oder 'max'.",
   "Failed to determine the context window for '{model}'. Define context_window in the settings or config file.": "Kontextfenster für '{model}' konnte nicht ermittelt werden. Definieren Sie context_window in den Einstellungen.",
   "Model '{model}' is a thinking-only model. reasoning_effort='disabled' is not supported; thinking will remain enabled.": "Modell '{model}' ist ein reines Denkmodell. reasoning_effort='disabled' wird nicht unterstützt; Denken bleibt aktiviert.",
   "Invalid reasoning effort '{effort}'. Allowed values are: {allowed}": "Ungültiger Denkaufwand '{effort}'. Erlaubte Werte: {allowed}",

--- a/ollama_agent/i18n/locales/es.json
+++ b/ollama_agent/i18n/locales/es.json
@@ -295,6 +295,7 @@
   "Failed to fetch metadata for '{model}': {exc}": "Error al obtener metadatos de '{model}': {exc}",
   "Model '{model}' does not support tools.": "El modelo '{model}' no admite herramientas.",
   "context_window must be greater than zero.": "context_window debe ser mayor que cero.",
+  "Invalid context_window '{value}'. Expected a positive integer or 'max'.": "context_window no válido '{value}'. Se esperaba un entero positivo o 'max'.",
   "Failed to determine the context window for '{model}'. Define context_window in the settings or config file.": "No se pudo determinar la ventana de contexto para '{model}'. Define context_window en los ajustes o archivo de configuración.",
   "Model '{model}' is a thinking-only model. reasoning_effort='disabled' is not supported; thinking will remain enabled.": "El modelo '{model}' es de solo razonamiento. reasoning_effort='disabled' no está admitido; el pensamiento permanecerá activado.",
   "Invalid reasoning effort '{effort}'. Allowed values are: {allowed}": "Esfuerzo de razonamiento no válido '{effort}'. Los valores permitidos son: {allowed}",

--- a/ollama_agent/i18n/locales/fr.json
+++ b/ollama_agent/i18n/locales/fr.json
@@ -295,6 +295,7 @@
   "Failed to fetch metadata for '{model}': {exc}": "Échec de récupération des métadonnées pour '{model}' : {exc}",
   "Model '{model}' does not support tools.": "Le modèle '{model}' ne supporte pas les outils.",
   "context_window must be greater than zero.": "context_window doit être supérieur à zéro.",
+  "Invalid context_window '{value}'. Expected a positive integer or 'max'.": "context_window non valide '{value}'. Un entier positif ou 'max' était attendu.",
   "Failed to determine the context window for '{model}'. Define context_window in the settings or config file.": "Impossible de déterminer la fenêtre de contexte pour '{model}'. Définissez context_window dans les paramètres ou le fichier de configuration.",
   "Model '{model}' is a thinking-only model. reasoning_effort='disabled' is not supported; thinking will remain enabled.": "Le modèle '{model}' est un modèle à raisonnement seul. reasoning_effort='disabled' n'est pas supporté ; la réflexion restera activée.",
   "Invalid reasoning effort '{effort}'. Allowed values are: {allowed}": "Effort de raisonnement invalide '{effort}'. Valeurs autorisées : {allowed}",

--- a/ollama_agent/i18n/locales/hi.json
+++ b/ollama_agent/i18n/locales/hi.json
@@ -295,6 +295,7 @@
   "Failed to fetch metadata for '{model}': {exc}": "'{model}' के लिए मेटाडेटा प्राप्त करने में विफल: {exc}",
   "Model '{model}' does not support tools.": "मॉडल '{model}' टूल का समर्थन नहीं करता है।",
   "context_window must be greater than zero.": "context_window शून्य से बड़ा होना चाहिए।",
+  "Invalid context_window '{value}'. Expected a positive integer or 'max'.": "अमान्य context_window '{value}'। धनात्मक पूर्णांक या 'max' अपेक्षित है।",
   "Failed to determine the context window for '{model}'. Define context_window in the settings or config file.": "'{model}' के लिए संदर्भ विंडो निर्धारित करने में विफल। सेटिंग्स या कॉन्फ़िग फ़ाइल में context_window परिभाषित करें।",
   "Model '{model}' is a thinking-only model. reasoning_effort='disabled' is not supported; thinking will remain enabled.": "मॉडल '{model}' केवल-सोचने वाला मॉडल है। reasoning_effort='disabled' समर्थित नहीं है; थिंकिंग सक्षम रहेगी।",
   "Invalid reasoning effort '{effort}'. Allowed values are: {allowed}": "अमान्य रीज़निंग प्रयास '{effort}'। अनुमत मान हैं: {allowed}",

--- a/ollama_agent/i18n/locales/it.json
+++ b/ollama_agent/i18n/locales/it.json
@@ -295,6 +295,7 @@
   "Failed to fetch metadata for '{model}': {exc}": "Impossibile recuperare i metadati per '{model}': {exc}",
   "Model '{model}' does not support tools.": "Il modello '{model}' non supporta i tool.",
   "context_window must be greater than zero.": "context_window deve essere maggiore di zero.",
+  "Invalid context_window '{value}'. Expected a positive integer or 'max'.": "context_window non valido '{value}'. Previsto un numero intero positivo o 'max'.",
   "Failed to determine the context window for '{model}'. Define context_window in the settings or config file.": "Impossibile determinare la finestra di contesto per '{model}'. Definisci context_window nelle impostazioni.",
   "Model '{model}' is a thinking-only model. reasoning_effort='disabled' is not supported; thinking will remain enabled.": "Il modello '{model}' è solo di ragionamento. reasoning_effort='disabled' non è supportato; il pensiero rimarrà attivo.",
   "Invalid reasoning effort '{effort}'. Allowed values are: {allowed}": "Sforzo di ragionamento non valido '{effort}'. Valori ammessi: {allowed}",

--- a/ollama_agent/i18n/locales/ja.json
+++ b/ollama_agent/i18n/locales/ja.json
@@ -295,6 +295,7 @@
   "Failed to fetch metadata for '{model}': {exc}": "モデル '{model}' のメタデータ取得に失敗しました: {exc}",
   "Model '{model}' does not support tools.": "モデル '{model}' はツール呼び出しをサポートしていません。",
   "context_window must be greater than zero.": "context_window は 0 より大きい必要があります。",
+  "Invalid context_window '{value}'. Expected a positive integer or 'max'.": "無効な context_window '{value}' です。正の整数または 'max' を指定してください。",
   "Failed to determine the context window for '{model}'. Define context_window in the settings or config file.": "モデル '{model}' のコンテキストウィンドウサイズを特定できませんでした。設定ファイルで context_window を定義してください。",
   "Model '{model}' is a thinking-only model. reasoning_effort='disabled' is not supported; thinking will remain enabled.": "モデル '{model}' は思考専用モデルです。reasoning_effort='disabled' はサポートされておらず、思考は有効のままになります。",
   "Invalid reasoning effort '{effort}'. Allowed values are: {allowed}": "無効な思考レベル '{effort}' です。許可される値: {allowed}",

--- a/ollama_agent/i18n/locales/pt.json
+++ b/ollama_agent/i18n/locales/pt.json
@@ -295,6 +295,7 @@
   "Failed to fetch metadata for '{model}': {exc}": "Falha ao obter metadados de '{model}': {exc}",
   "Model '{model}' does not support tools.": "O modelo '{model}' não suporta ferramentas.",
   "context_window must be greater than zero.": "context_window deve ser maior que zero.",
+  "Invalid context_window '{value}'. Expected a positive integer or 'max'.": "context_window inválido '{value}'. Esperava-se um número inteiro positivo ou 'max'.",
   "Failed to determine the context window for '{model}'. Define context_window in the settings or config file.": "Não foi possível determinar a janela de contexto de '{model}'. Defina context_window nas configurações.",
   "Model '{model}' is a thinking-only model. reasoning_effort='disabled' is not supported; thinking will remain enabled.": "O modelo '{model}' é somente de raciocínio. reasoning_effort='disabled' não é suportado; o pensamento continuará ativado.",
   "Invalid reasoning effort '{effort}'. Allowed values are: {allowed}": "Esforço de raciocínio inválido '{effort}'. Valores permitidos: {allowed}",

--- a/ollama_agent/i18n/locales/ru.json
+++ b/ollama_agent/i18n/locales/ru.json
@@ -295,6 +295,7 @@
   "Failed to fetch metadata for '{model}': {exc}": "Не удалось получить метаданные для '{model}': {exc}",
   "Model '{model}' does not support tools.": "Модель '{model}' не поддерживает вызов инструментов.",
   "context_window must be greater than zero.": "context_window должно быть больше нуля.",
+  "Invalid context_window '{value}'. Expected a positive integer or 'max'.": "Недопустимое значение context_window '{value}'. Ожидалось положительное целое число или 'max'.",
   "Failed to determine the context window for '{model}'. Define context_window in the settings or config file.": "Не удалось определить размер контекстного окна для '{model}'. Укажите context_window в настройках.",
   "Model '{model}' is a thinking-only model. reasoning_effort='disabled' is not supported; thinking will remain enabled.": "Модель '{model}' является моделью только с рассуждениями. reasoning_effort='disabled' не поддерживается; рассуждения останутся включенными.",
   "Invalid reasoning effort '{effort}'. Allowed values are: {allowed}": "Недопустимый уровень рассуждений '{effort}'. Допустимые значения: {allowed}",

--- a/ollama_agent/i18n/locales/zh.json
+++ b/ollama_agent/i18n/locales/zh.json
@@ -295,6 +295,7 @@
   "Failed to fetch metadata for '{model}': {exc}": "获取模型 '{model}' 的元数据失败：{exc}",
   "Model '{model}' does not support tools.": "模型 '{model}' 不支持工具调用。",
   "context_window must be greater than zero.": "context_window 必须大于零。",
+  "Invalid context_window '{value}'. Expected a positive integer or 'max'.": "无效的 context_window '{value}'。应为正整数或 'max'。",
   "Failed to determine the context window for '{model}'. Define context_window in the settings or config file.": "无法确定模型 '{model}' 的上下文窗口大小。请在设置或配置文件中定义 context_window。",
   "Model '{model}' is a thinking-only model. reasoning_effort='disabled' is not supported; thinking will remain enabled.": "模型 '{model}' 为纯思考模型。不支持 reasoning_effort='disabled'；思考将保持开启。",
   "Invalid reasoning effort '{effort}'. Allowed values are: {allowed}": "无效的推理强度 '{effort}'。允许的值为：{allowed}",

--- a/ollama_agent/interfaces/tui_components.py
+++ b/ollama_agent/interfaces/tui_components.py
@@ -36,7 +36,11 @@ class AgentHeader(Static):
     def update_header(self) -> None:
         ms = self.repl.runtime.settings.model
         tokens = self.repl.runtime.last_context_tokens
-        num_ctx = ms.context_window
+        num_ctx = (
+            self.repl.runtime.effective_context_window
+            if isinstance(self.repl.runtime.effective_context_window, int) and self.repl.runtime.effective_context_window > 0
+            else (ms.context_window if isinstance(ms.context_window, int) else 0)
+        )
 
         if isinstance(num_ctx, int) and num_ctx > 0:
             tokens_val = tokens

--- a/ollama_agent/settings/config.py
+++ b/ollama_agent/settings/config.py
@@ -68,7 +68,7 @@ class ModelSettings:
     min_p: float | None = None
     presence_penalty: float | None = None
     repeat_penalty: float | None = None
-    context_window: int = 10000
+    context_window: int | str = 10000
     reasoning_effort: str = "medium"
 
 
@@ -114,7 +114,7 @@ class SubAgentSettings:
     description: str = ""
     system_prompt: str = ""
     model: str = ""
-    context_window: int = 0
+    context_window: int | str = 0
     mcp_servers: list[SubAgentMCPServer] = field(default_factory=list)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,6 +114,29 @@ class TestConfigManagement(unittest.TestCase):
         s = Settings.from_dict(raw)
         self.assertEqual(s.model.repeat_penalty, 1.3)
 
+    def test_model_and_subagent_context_window_max(self) -> None:
+        raw = {
+            "model": {
+                "name": "qwen2.5-coder:32b",
+                "context_window": "max",
+            },
+            "subagents": [
+                {
+                    "name": "researcher",
+                    "description": "Deep researcher",
+                    "context_window": "max",
+                }
+            ],
+        }
+        s = Settings.from_dict(raw)
+        self.assertEqual(s.model.context_window, "max")
+        self.assertEqual(s.subagents[0].context_window, "max")
+
+        save_settings(s, self.settings_file)
+        loaded = load_settings(self.settings_file)
+        self.assertEqual(loaded.model.context_window, "max")
+        self.assertEqual(loaded.subagents[0].context_window, "max")
+
     def test_setup_environment_injects_langsmith_variables(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
             s = Settings(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -133,9 +133,63 @@ class TestModelsLogic(unittest.IsolatedAsyncioTestCase):
         resolved = await resolve_context_window("test-model", 4096, "http://localhost:11434")
         self.assertEqual(resolved, 4096)
 
+    async def test_resolve_context_window_string_int(self) -> None:
+        resolved = await resolve_context_window("test-model", "16384", "http://localhost:11434")
+        self.assertEqual(resolved, 16384)
+
     async def test_resolve_context_window_invalid_explicit_value_raises(self) -> None:
         with self.assertRaises(ModelContextWindowError):
             await resolve_context_window("test-model", 0, "http://localhost:11434")
+
+        with self.assertRaises(ModelContextWindowError):
+            await resolve_context_window("test-model", -10, "http://localhost:11434")
+
+        with self.assertRaises(ModelContextWindowError):
+            await resolve_context_window("test-model", "invalid", "http://localhost:11434")
+
+    @patch("ollama_agent.core.models._show_model")
+    async def test_resolve_context_window_max(self, mock_show: AsyncMock) -> None:
+        mock_show.return_value = MagicMock(
+            model_info={"llama.context_length": 131072},
+            parameters="",
+            modelfile="",
+        )
+        resolved = await resolve_context_window("llama3.3:70b", "max", "http://localhost:11434")
+        self.assertEqual(resolved, 131072)
+
+        # Case-insensitive
+        resolved_upper = await resolve_context_window("llama3.3:70b", "MAX", "http://localhost:11434")
+        self.assertEqual(resolved_upper, 131072)
+
+        # Ollama SDK modelinfo attribute format (without underscore)
+        mock_show.return_value = MagicMock(
+            model_info=None,
+            modelinfo={"gemma4.context_length": 262144},
+            parameters="",
+            modelfile="",
+        )
+        resolved_sdk = await resolve_context_window("gemma4:26b-a4b-it-qat", "max", "http://localhost:11434")
+        self.assertEqual(resolved_sdk, 262144)
+
+    @patch("ollama_agent.core.models._show_model")
+    async def test_resolve_context_window_max_modelfile_fallback(self, mock_show: AsyncMock) -> None:
+        mock_show.return_value = MagicMock(
+            model_info={},
+            parameters="PARAMETER num_ctx 32768",
+            modelfile="",
+        )
+        resolved = await resolve_context_window("custom-model", "max", "http://localhost:11434")
+        self.assertEqual(resolved, 32768)
+
+    @patch("ollama_agent.core.models._show_model")
+    async def test_resolve_context_window_max_unresolved_raises(self, mock_show: AsyncMock) -> None:
+        mock_show.return_value = MagicMock(
+            model_info={},
+            parameters="",
+            modelfile="",
+        )
+        with self.assertRaises(ModelContextWindowError):
+            await resolve_context_window("unknown-model", "max", "http://localhost:11434")
 
     @patch("ollama_agent.core.models.resolve_context_window", AsyncMock(return_value=8192))
     @patch("ollama_agent.core.models.resolve_ollama_reasoning", AsyncMock(return_value=True))


### PR DESCRIPTION
## Summary
- Allow setting `model.context_window` and subagent `context_window` to `'max'` (or positive integers) to dynamically resolve the maximum supported context size from Ollama model metadata.
- Clean up context window resolution hierarchy in `resolve_context_window` and update TUI header formatting to read `effective_context_window`.
- Add unit tests for `'max'` context window resolution and update documentation across locales.