### PR TITLE
fix(repl): prevent Textual text selection crash on detached widgets (v0.8.7)

### DIFF
--- a/ollama_agent/__init__.py
+++ b/ollama_agent/__init__.py
@@ -1,7 +1,7 @@
 """Ollama Agent package."""
 from __future__ import annotations
 
-__version__ = "0.8.6"
+__version__ = "0.8.7"
 
 from .agent import AgentRuntime
 from .core import (

--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -13,10 +13,11 @@ from rich.text import Text
 
 from textual import events
 from textual.app import App, ComposeResult
-from textual.worker import Worker
 from textual.containers import Container, Horizontal, ScrollableContainer
+from textual.screen import Screen
 from textual.widgets import OptionList, Static, TextArea
 from textual.widgets.option_list import Option
+from textual.worker import Worker
 from langchain_core.messages.utils import count_tokens_approximately
 from langgraph.types import Command
 
@@ -53,6 +54,22 @@ from ..streaming import StreamingRenderer, stream_agent_events
 _AT_MENTION_RE = re.compile(
     r"""(?:^|[\s\(\[\{<])@(?:"([^"]*)|'([^']*)|([^\s"'\(\[\{<>,;]*))$"""
 )
+
+# Textual workaround: prevent crash when clicking/dragging on unmounted/detached widgets during text selection
+_original_screen_forward_event = Screen._forward_event
+
+
+def _safe_screen_forward_event(self: Screen, event: events.Event) -> None:
+    try:
+        _original_screen_forward_event(self, event)
+    except AttributeError as err:
+        if "'NoneType' object has no attribute 'region'" in str(err):
+            self._select_state = None
+            return
+        raise
+
+
+Screen._forward_event = _safe_screen_forward_event
 
 
 def _get_root_commands() -> list[tuple[str, str]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ollama-agent"
-version = "0.8.6"
+version = "0.8.7"
 description = "AI agent to interact with local language models through Ollama"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -152,3 +152,34 @@ class TestAppClipboardIntegration(unittest.IsolatedAsyncioTestCase):
                 mock_sys_copy.assert_called()
                 copied_arg = mock_sys_copy.call_args[0][0]
                 self.assertIn("Copy action message", copied_arg)
+
+    async def test_screen_forward_event_handles_detached_widget_gracefully(self) -> None:
+        repl_mock = MagicMock(spec=OllamaREPL)
+        repl_mock.runtime = MagicMock()
+        repl_mock.runtime.yolo_mode = False
+        repl_mock._rag_ctx = None
+        repl_mock.runtime.settings.model.name = "gemma4:26b"
+        repl_mock.runtime.settings.model.reasoning_effort = "medium"
+
+        app = OllamaAgentApp(repl_mock)
+        async with app.run_test() as pilot:
+            event = events.MouseDown(None, 5, 5, 0, 0, 1, False, False, False)
+            with patch("ollama_agent.interfaces.repl._original_screen_forward_event", side_effect=AttributeError("'NoneType' object has no attribute 'region'")):
+                app.screen._forward_event(event)
+                self.assertIsNone(app.screen._select_state)
+
+    async def test_screen_forward_event_reraises_other_attribute_error(self) -> None:
+        repl_mock = MagicMock(spec=OllamaREPL)
+        repl_mock.runtime = MagicMock()
+        repl_mock.runtime.yolo_mode = False
+        repl_mock._rag_ctx = None
+        repl_mock.runtime.settings.model.name = "gemma4:26b"
+        repl_mock.runtime.settings.model.reasoning_effort = "medium"
+
+        app = OllamaAgentApp(repl_mock)
+        async with app.run_test() as pilot:
+            event = events.MouseDown(None, 5, 5, 0, 0, 1, False, False, False)
+            with patch("ollama_agent.interfaces.repl._original_screen_forward_event", side_effect=AttributeError("'CustomType' object has no attribute 'something_else'")):
+                with self.assertRaises(AttributeError):
+                    app.screen._forward_event(event)
+


### PR DESCRIPTION
### Summary
- Protect Textual `Screen._forward_event` from raising `AttributeError: 'NoneType' object has no attribute 'region'` when clicking or dragging over unmounted/detached widgets during Markdown streaming.
- Add regression unit tests in `tests/test_clipboard.py`.
- Bump package version to 0.8.7.