### PR TITLE
fix: remove private API coupling, silent error swallowing, and latent…

### DIFF
--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -16,8 +16,6 @@ from deepagents import create_deep_agent
 from deepagents.backends import CompositeBackend, FilesystemBackend, LocalShellBackend
 from deepagents.middleware.summarization import create_summarization_tool_middleware
 from langchain_core.messages.utils import count_tokens_approximately
-from langchain_core.runnables import RunnableConfig
-from langchain_core.runnables.config import var_child_runnable_config
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.types import Command
 
@@ -56,6 +54,17 @@ from .builtin_tools import (
     rag_search,
     set_active_thread_id,
 )
+from .compaction import (
+    HISTORY_PATH_PREFIX,
+    KEEP_RECENT_MESSAGES,
+    apply_summarization_event,
+    build_summary_message,
+    compute_state_cutoff,
+    find_safe_cutoff,
+    generate_summary,
+    new_session_id,
+    offload_history,
+)
 from .middleware import stream_tool_events_mw
 from .subagents import build_subagents
 
@@ -93,7 +102,7 @@ class AgentRuntime:
     effective_model_params: dict[str, tuple[Any, str]] = field(default_factory=dict, init=False)
     graph: Any = field(default=None, init=False, repr=False)
     _backend: Any = field(default=None, init=False, repr=False)
-    _summarization_mw: Any = field(default=None, init=False, repr=False)
+    _model: Any = field(default=None, init=False, repr=False)
     _instructions: str = field(default="", init=False)
     _exit_stack: contextlib.AsyncExitStack = field(
         default_factory=contextlib.AsyncExitStack, init=False, repr=False
@@ -217,7 +226,7 @@ class AgentRuntime:
 
         summarization_tool_mw = create_summarization_tool_middleware(model, backend)
         self._backend = backend
-        self._summarization_mw = summarization_tool_mw._summarization
+        self._model = model
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -323,68 +332,47 @@ class AgentRuntime:
     async def compact_context(self, thread_id: str = "") -> dict[str, Any]:
         """Compact conversation history for the specified thread into a summary."""
         thread = thread_id or self.thread_id
-        if self.graph is None or self._summarization_mw is None or self._backend is None:
+        if self.graph is None:
             await self.reload()
-        assert self.graph is not None and self._summarization_mw is not None and self._backend is not None
+        assert self.graph is not None and self._model is not None
 
-        config: RunnableConfig = {"configurable": {"thread_id": thread}}
+        config = {"configurable": {"thread_id": thread}}
         state = await self.graph.aget_state(config)
-        if not state or not state.values or "messages" not in state.values:
+        values: dict[str, Any] = state.values if state and state.values else {}
+        raw_messages = list(values.get("messages") or [])
+        if not raw_messages:
             return {"success": False, "message": _("No messages in session to compact.")}
 
-        messages = state.values["messages"]
-        event = state.values.get("_summarization_event")
-        effective = self._summarization_mw._apply_event_to_messages(messages, event)
+        prior_event = values.get("_summarization_event")
+        effective = apply_summarization_event(raw_messages, prior_event)
 
-        if len(effective) < 2:
+        cutoff = find_safe_cutoff(effective, KEEP_RECENT_MESSAGES)
+        if cutoff <= 0:
             return {
                 "success": False,
                 "message": _("Not enough messages in session to compact (at least 2 messages required)."),
             }
+        to_summarize, preserved = effective[:cutoff], effective[cutoff:]
 
-        cutoff = self._summarization_mw._determine_cutoff_index(effective)
-        if cutoff <= 0:
-            cutoff = self._summarization_mw._lc_helper._find_safe_cutoff(
-                effective, min(2, len(effective) - 1)
-            )
-            if cutoff <= 0:
-                cutoff = max(1, len(effective) - 1)
-
-        to_summarize, preserved = self._summarization_mw._partition_messages(
-            effective, cutoff
-        )
-        if not to_summarize:
-            return {
-                "success": False,
-                "message": _("No messages eligible for summarization."),
-            }
-
-        token = var_child_runnable_config.set(config)
-        try:
-            file_path, summary = await asyncio.gather(
-                self._summarization_mw._aoffload_to_backend(self._backend, to_summarize),
-                self._summarization_mw._acreate_summary(to_summarize),
-            )
-        finally:
-            var_child_runnable_config.reset(token)
-
-        new_messages = self._summarization_mw._build_new_messages_with_path(
-            summary, file_path
-        )
-        state_cutoff_index = self._summarization_mw._compute_state_cutoff(
-            event, cutoff
+        session_id = new_session_id(values)
+        history_path = f"{HISTORY_PATH_PREFIX}/{session_id}.md"
+        summary, file_path = await asyncio.gather(
+            generate_summary(self._model, to_summarize),
+            offload_history(self._backend, to_summarize, history_path),
         )
 
         new_event: dict[str, Any] = {
-            "cutoff_index": state_cutoff_index,
-            "summary_message": new_messages[0],
+            "cutoff_index": compute_state_cutoff(prior_event, cutoff),
+            "summary_message": build_summary_message(summary, file_path),
             "file_path": file_path,
         }
-
-        await self.graph.aupdate_state(config, {"_summarization_event": new_event})
+        await self.graph.aupdate_state(
+            config,
+            {"_summarization_event": new_event, "_summarization_session_id": session_id},
+        )
 
         self.last_context_tokens = count_tokens_approximately(
-            [new_messages[0], *preserved]
+            [new_event["summary_message"], *preserved]
         )
 
         return {
@@ -395,6 +383,28 @@ class AgentRuntime:
             "summary": summary,
         }
 
+    async def get_thread_messages(self, thread_id: str = "") -> list[Any]:
+        """Return the raw stored messages for a thread (empty when unknown)."""
+        if self.graph is None:
+            await self.reload()
+        assert self.graph is not None
+        config = {"configurable": {"thread_id": thread_id or self.thread_id}}
+        state = await self.graph.aget_state(config)
+        values: dict[str, Any] = state.values if state and state.values else {}
+        return list(values.get("messages") or [])
+
+    async def count_effective_tokens(self, thread_id: str = "") -> int:
+        """Count tokens of the effective context for a thread (after compaction)."""
+        if self.graph is None:
+            await self.reload()
+        assert self.graph is not None
+        config = {"configurable": {"thread_id": thread_id or self.thread_id}}
+        state = await self.graph.aget_state(config)
+        values: dict[str, Any] = state.values if state and state.values else {}
+        effective = apply_summarization_event(
+            list(values.get("messages") or []), values.get("_summarization_event")
+        )
+        return count_tokens_approximately(effective)
 
     async def set_model(self, model_name: str) -> str:
         self.settings.model.name = model_name

--- a/ollama_agent/agent/builtin_tools.py
+++ b/ollama_agent/agent/builtin_tools.py
@@ -11,6 +11,7 @@ from ..core import RAGToolResult
 from ..i18n import _
 from ..rag import RAGError, RAGManager
 from .episodic_memory import (
+    HistoryError,
     format_past_conversations_context,
     search_past_conversations_in_db,
 )
@@ -70,11 +71,14 @@ async def rag_search(query: str, top_k: int | None = None) -> RAGToolResult:
 @tool
 async def search_past_conversations(query: str, limit: int = 3) -> str:
     """Search past conversation sessions and episodic memory by keywords, topics, or dates (e.g. 'yesterday', 'auth', 'database'). Returns timestamped excerpts of previous sessions."""
-    results = search_past_conversations_in_db(
-        query=query,
-        exclude_thread_id=get_active_thread_id(),
-        limit=limit,
-    )
+    try:
+        results = search_past_conversations_in_db(
+            query=query,
+            exclude_thread_id=get_active_thread_id(),
+            limit=limit,
+        )
+    except HistoryError as exc:
+        return _("Error searching past conversations: {exc}", exc=exc)
     return format_past_conversations_context(results)
 
 

--- a/ollama_agent/agent/compaction.py
+++ b/ollama_agent/agent/compaction.py
@@ -1,0 +1,152 @@
+"""Manual conversation compaction built on deepagents' public contracts.
+
+Interoperates with deepagents' ``SummarizationMiddleware`` through the
+documented state contract: the ``_summarization_event`` key holds a
+``SummarizationEvent`` TypedDict and the effective conversation the model
+sees is ``[summary_message] + messages[cutoff_index:]``. History offload
+appends to a single markdown file per session under
+``/conversation_history/`` (deepagents' default prefix).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from deepagents.middleware.summarization import DEEPAGENTS_DEFAULT_SUMMARY_PROMPT
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.messages.utils import get_buffer_string
+
+_log = logging.getLogger(__name__)
+
+#: Path prefix used by deepagents to store conversation history files.
+HISTORY_PATH_PREFIX = "/conversation_history"
+
+#: Number of recent messages preserved (not summarized) by manual compaction.
+KEEP_RECENT_MESSAGES = 2
+
+_SUMMARY_SOURCE = "summarization"
+
+
+def is_summary_message(msg: Any) -> bool:
+    """Check whether *msg* is a summary HumanMessage produced by compaction."""
+    return isinstance(msg, HumanMessage) and msg.additional_kwargs.get("lc_source") == _SUMMARY_SOURCE
+
+
+def apply_summarization_event(messages: list[Any], event: dict[str, Any] | None) -> list[Any]:
+    """Reconstruct the effective message list from raw state and a prior event.
+
+    The effective conversation is ``[summary_message] + messages[cutoff:]``.
+    Malformed events fall back to the full raw list (matching deepagents).
+    """
+    if event is None:
+        return list(messages)
+    try:
+        summary_msg = event["summary_message"]
+        cutoff = event["cutoff_index"]
+    except (KeyError, TypeError) as exc:
+        _log.warning("Malformed summarization event (%s); using full history", exc)
+        return list(messages)
+    if cutoff > len(messages):
+        return [summary_msg]
+    return [summary_msg, *messages[cutoff:]]
+
+
+def compute_state_cutoff(prior_event: dict[str, Any] | None, effective_cutoff: int) -> int:
+    """Translate an effective-list cutoff into an absolute state index.
+
+    The summary message occupies effective index 0 but no state slot,
+    hence the ``-1`` adjustment when a prior event exists.
+    """
+    if prior_event is None:
+        return effective_cutoff
+    prior = prior_event.get("cutoff_index")
+    return prior + effective_cutoff - 1 if isinstance(prior, int) else effective_cutoff
+
+
+def find_safe_cutoff(messages: list[Any], keep: int) -> int:
+    """Return the index where messages can be cut keeping the last *keep*.
+
+    Never splits an AI/tool-call request from its tool outputs: if the cut
+    lands on a ToolMessage, the cutoff moves back to include the owning
+    AIMessage (or forward past the orphaned tool outputs). Returns 0 when
+    there are not enough messages to compact.
+    """
+    if len(messages) <= keep:
+        return 0
+    target = len(messages) - keep
+    if not isinstance(messages[target], ToolMessage):
+        return target
+
+    tool_call_ids: set[str] = set()
+    idx = target
+    while idx < len(messages) and isinstance(messages[idx], ToolMessage):
+        if messages[idx].tool_call_id:
+            tool_call_ids.add(messages[idx].tool_call_id)
+        idx += 1
+
+    for i in range(target - 1, -1, -1):
+        msg = messages[i]
+        if isinstance(msg, AIMessage) and msg.tool_calls:
+            ai_ids = {tc.get("id") for tc in msg.tool_calls if tc.get("id")}
+            if tool_call_ids & ai_ids:
+                return i
+
+    return idx
+
+
+def build_summary_message(summary: str, file_path: str | None) -> HumanMessage:
+    """Build the HumanMessage that replaces the summarized history."""
+    if file_path is not None:
+        content = (
+            "You are in the middle of a conversation that has been summarized.\n\n"
+            f"The full conversation history has been saved to {file_path} should you "
+            "need to refer back to it for details.\n\n"
+            "A condensed summary follows:\n\n"
+            f"<summary>\n{summary}\n</summary>"
+        )
+    else:
+        content = f"Here is a summary of the conversation to date:\n\n{summary}"
+    return HumanMessage(content=content, additional_kwargs={"lc_source": _SUMMARY_SOURCE})
+
+
+async def generate_summary(model: Any, messages: list[Any]) -> str:
+    """Generate a structured summary of *messages* using *model*."""
+    formatted = get_buffer_string(messages, format="xml")
+    prompt = DEEPAGENTS_DEFAULT_SUMMARY_PROMPT.format(messages=formatted).rstrip()
+    response = await model.ainvoke(prompt)
+    return response.text.strip()
+
+
+async def offload_history(backend: Any, messages: list[Any], path: str) -> str | None:
+    """Append *messages* to the session history markdown file on *backend*.
+
+    Returns the file path on success, or None when offloading fails
+    (non-fatal: compaction proceeds with the summary alone).
+    """
+    filtered = [m for m in messages if not is_summary_message(m)]
+    timestamp = datetime.now(UTC).isoformat()
+    section = f"## Summarized at {timestamp}\n\n{get_buffer_string(filtered, format='xml')}\n\n"
+
+    existing = ""
+    try:
+        responses = await backend.adownload_files([path])
+        if responses and responses[0].content is not None and responses[0].error is None:
+            existing = responses[0].content.decode("utf-8")
+    except Exception as exc:
+        _log.debug("No existing history at %s (%s): %s", path, type(exc).__name__, exc)
+
+    combined = existing + section
+    result = await backend.aedit(path, existing, combined) if existing else await backend.awrite(path, combined)
+    if result is None or getattr(result, "error", None):
+        _log.warning("Failed to offload conversation history to %s", path)
+        return None
+    return path
+
+
+def new_session_id(state_values: dict[str, Any]) -> str:
+    """Reuse the persisted summarization session id or create a fresh one."""
+    existing = state_values.get("_summarization_session_id")
+    return existing if isinstance(existing, str) and existing else f"session_{uuid.uuid4().hex}"

--- a/ollama_agent/agent/episodic_memory.py
+++ b/ollama_agent/agent/episodic_memory.py
@@ -17,6 +17,18 @@ from ..settings.paths import HISTORY_DB_PATH
 _serializer = JsonPlusSerializer()
 
 
+class HistoryError(RuntimeError):
+    """Raised when the conversation history database cannot be read."""
+
+
+def connect_history(db_path: Path) -> sqlite3.Connection:
+    """Open the history database, raising HistoryError when unreadable."""
+    try:
+        return sqlite3.connect(str(db_path))
+    except sqlite3.Error as e:
+        raise HistoryError(_("Failed to open history database {db_path}: {e}", db_path=db_path, e=e)) from e
+
+
 def format_iso_timestamp(ts: str) -> str:
     """Format ISO timestamp into a human-readable UTC string (YYYY-MM-DD HH:MM UTC)."""
     if not ts:
@@ -24,15 +36,16 @@ def format_iso_timestamp(ts: str) -> str:
     return datetime.fromisoformat(ts).strftime("%Y-%m-%d %H:%M UTC")
 
 
-def load_past_user_prompts(db_path: Path = HISTORY_DB_PATH) -> list[str]:
+def load_past_user_prompts(db_path: Path | None = None) -> list[str]:
     """Load past user prompt strings from the SQLite history database in chronological order."""
+    db_path = db_path if db_path is not None else HISTORY_DB_PATH
     if not db_path.exists():
         return []
 
     prompts: list[str] = []
     seen: set[str] = set()
     try:
-        with sqlite3.connect(str(db_path)) as conn:
+        with connect_history(db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "SELECT type, value FROM writes WHERE channel = 'messages' ORDER BY rowid ASC"
@@ -47,19 +60,22 @@ def load_past_user_prompts(db_path: Path = HISTORY_DB_PATH) -> list[str]:
                         if text and text not in seen:
                             seen.add(text)
                             prompts.append(text)
-    except (sqlite3.Error, OSError):
-        return []
+    except sqlite3.Error as e:
+        raise HistoryError(_("Failed to read history database {db_path}: {e}", db_path=db_path, e=e)) from e
+    except OSError as e:
+        raise HistoryError(_("Failed to read history database {db_path}: {e}", db_path=db_path, e=e)) from e
     return prompts
 
 
 def load_past_conversations(
-    db_path: Path = HISTORY_DB_PATH,
+    db_path: Path | None = None,
     exclude_thread_id: str = "",
 ) -> dict[str, dict[str, Any]]:
     """Load conversation messages and timestamps grouped by thread_id from SQLite history.
 
     Threads matching ``exclude_thread_id`` (e.g. active conversation) are skipped.
     """
+    db_path = db_path if db_path is not None else HISTORY_DB_PATH
     if not db_path.exists():
         return {}
 
@@ -67,7 +83,7 @@ def load_past_conversations(
     thread_messages: defaultdict[str, list[Any]] = defaultdict(list)
 
     try:
-        with sqlite3.connect(str(db_path)) as conn:
+        with connect_history(db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "SELECT thread_id, type, checkpoint FROM checkpoints ORDER BY rowid ASC"
@@ -90,8 +106,10 @@ def load_past_conversations(
                     thread_messages[tid].extend(msgs)
                 else:
                     thread_messages[tid].append(msgs)
-    except (sqlite3.Error, OSError):
-        return {}
+    except sqlite3.Error as e:
+        raise HistoryError(_("Failed to read history database {db_path}: {e}", db_path=db_path, e=e)) from e
+    except OSError as e:
+        raise HistoryError(_("Failed to read history database {db_path}: {e}", db_path=db_path, e=e)) from e
 
     conversations: dict[str, dict[str, Any]] = {}
     for tid, msgs in thread_messages.items():
@@ -107,7 +125,7 @@ def load_past_conversations(
 
 def search_past_conversations_in_db(
     query: str,
-    db_path: Path = HISTORY_DB_PATH,
+    db_path: Path | None = None,
     exclude_thread_id: str = "",
     limit: int = 3,
 ) -> list[dict[str, Any]]:
@@ -155,7 +173,7 @@ def search_past_conversations_in_db(
                 if total_chars > 1200:
                     break
 
-        if match_count > 0 and snippets:
+        if match_count > 0:
             scored_results.append({
                 "thread_id": tid,
                 "score": match_count,

--- a/ollama_agent/i18n/__init__.py
+++ b/ollama_agent/i18n/__init__.py
@@ -50,7 +50,7 @@ def detect_system_language() -> str:
             norm = _normalize_lang(loc)
             if norm in SUPPORTED_LOCALES:
                 return norm
-    except Exception:
+    except (OSError, ValueError):
         pass
 
     return DEFAULT_LOCALE

--- a/ollama_agent/interfaces/cli.py
+++ b/ollama_agent/interfaces/cli.py
@@ -6,8 +6,11 @@ import argparse
 import asyncio
 import inspect
 
+from rich.console import Console
+
 from ..agent import AgentRuntime
 from ..agent.builtin_tools import set_rag_manager
+from ..agent.episodic_memory import HistoryError
 from ..core import ALLOWED_REASONING_EFFORTS
 from ..i18n import _
 from ..rag import RAGContext, RAGManager, RAGError, load_rag_database
@@ -269,6 +272,9 @@ def handle_cli_commands(
                 if inspect.isawaitable(result):
                     asyncio.run(result)  # type: ignore[arg-type]
             except (SkillError, TaskError, RAGError):
+                raise SystemExit(1)
+            except HistoryError as exc:
+                Console().print(f"[red]{exc}[/red]")
                 raise SystemExit(1)
             return True
 

--- a/ollama_agent/interfaces/dispatch.py
+++ b/ollama_agent/interfaces/dispatch.py
@@ -9,6 +9,7 @@ from typing import Awaitable, Callable, Any
 
 from rich.console import Console
 
+from ..agent.episodic_memory import HistoryError
 from ..i18n import _
 from ..mcp import list_mcp_servers
 from ..settings import Settings
@@ -53,14 +54,28 @@ class REPLCommand:
     handler: Callable[[list[str]], object]
 
 
-async def safe_call(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
-    """Call *fn*(*args, **kwargs), awaiting if necessary and silencing SystemExit/domain errors."""
+async def safe_call(
+    fn: Callable[..., Any],
+    *args: Any,
+    console: Console | None = None,
+    **kwargs: Any,
+) -> None:
+    """Call *fn*(*args, **kwargs), awaiting if necessary.
+
+    Domain errors (SkillError, TaskError, RAGError) are swallowed because
+    every raiser prints a user-facing message before raising; they exist to
+    signal failure exit codes on the CLI. HistoryError is not printed by its
+    raisers, so it is reported here when a *console* is provided.
+    """
     try:
         result = fn(*args, **kwargs)
         if inspect.isawaitable(result):
             await result
-    except (SystemExit, SkillError, TaskError, RAGError):
+    except (SkillError, TaskError, RAGError):
         pass
+    except HistoryError as exc:
+        if console is not None:
+            console.print(f"[red]{exc}[/red]")
 
 
 REPL_SECTIONS: tuple[str, ...] = (

--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import re
 from collections.abc import Iterator
@@ -18,7 +19,6 @@ from textual.screen import Screen
 from textual.widgets import OptionList, Static, TextArea
 from textual.widgets.option_list import Option
 from textual.worker import Worker
-from langchain_core.messages.utils import count_tokens_approximately
 from langgraph.types import Command
 
 from .clipboard import copy_to_system_clipboard, get_system_clipboard
@@ -34,6 +34,7 @@ from .tui_components import (
 
 from ..agent import AgentRuntime
 from ..agent.builtin_tools import set_rag_manager, set_tool_timeout
+from ..agent.episodic_memory import HistoryError
 from ..core.common import extract_text
 from ..i18n import _
 from ..rag import RAGContext, RAGManager, load_rag_database
@@ -55,21 +56,19 @@ _AT_MENTION_RE = re.compile(
     r"""(?:^|[\s\(\[\{<])@(?:"([^"]*)|'([^']*)|([^\s"'\(\[\{<>,;]*))$"""
 )
 
-# Textual workaround: prevent crash when clicking/dragging on unmounted/detached widgets during text selection
-_original_screen_forward_event = Screen._forward_event
 
+class MainScreen(Screen):
+    """Default screen with a guard against Textual crashes when text selection
+    ends over a widget detached mid-drag (``parent`` is ``None``)."""
 
-def _safe_screen_forward_event(self: Screen, event: events.Event) -> None:
-    try:
-        _original_screen_forward_event(self, event)
-    except AttributeError as err:
-        if "'NoneType' object has no attribute 'region'" in str(err):
-            self._select_state = None
-            return
-        raise
-
-
-Screen._forward_event = _safe_screen_forward_event
+    def _forward_event(self, event: events.Event) -> None:
+        try:
+            super()._forward_event(event)
+        except AttributeError as err:
+            if "'NoneType' object has no attribute 'region'" in str(err):
+                self._select_state = None
+                return
+            raise
 
 
 def _get_root_commands() -> list[tuple[str, str]]:
@@ -104,6 +103,7 @@ def _get_subcommands() -> dict[str, list[tuple[str, str]]]:
             ("list", _("List all past sessions")),
             ("search", _("Search past sessions by keyword")),
             ("resume", _("Resume a previous session")),
+            ("switch", _("Switch to a previous session (alias for resume)")),
             ("new", _("Start a new session")),
             ("export", _("Export session to Markdown")),
             ("delete", _("Delete a session from history")),
@@ -243,6 +243,9 @@ class OllamaAgentApp(App):
         selected_text = self.screen.get_selected_text()
         if selected_text:
             self.copy_to_clipboard(selected_text)
+
+    def get_default_screen(self) -> Screen:
+        return MainScreen(id="_default")
 
     CSS_PATH = "repl.css"
 
@@ -392,7 +395,11 @@ class OllamaAgentApp(App):
                 ]
 
             if root_cmd == "/session" and sub_cmd in ("resume", "switch", "delete"):
-                sessions = get_available_sessions()
+                try:
+                    sessions = get_available_sessions()
+                except HistoryError as exc:
+                    logging.warning("Session autocomplete unavailable: %s", exc)
+                    return []
                 return [
                     (
                         f"{root_cmd} {sub_cmd} {s['thread_id']}",
@@ -598,35 +605,28 @@ class OllamaAgentApp(App):
                 scroll.mount(SystemMessage(f"[bold #f87171]✕ {_('Usage: /session resume <session_id>')}[/bold #f87171]"))
                 self._deferred_scroll()
                 return
-            resolved = resume_session(self.repl.console, args[1])
+            try:
+                resolved = resume_session(self.repl.console, args[1])
+            except HistoryError as exc:
+                scroll.mount(SystemMessage(f"[red]{exc}[/red]"))
+                self._deferred_scroll()
+                return
             if resolved:
                 self.repl.runtime.thread_id = resolved
                 await scroll.remove_children()
-                if self.repl.runtime.graph is not None:
-                    config = {"configurable": {"thread_id": resolved}}
-                    state = await self.repl.runtime.graph.aget_state(config)
-                    if state and state.values and "messages" in state.values:
-                        messages = state.values["messages"]
-                        event = state.values.get("_summarization_event")
-                        effective = (
-                            self.repl.runtime._summarization_mw._apply_event_to_messages(
-                                messages, event
-                            )
-                            if self.repl.runtime._summarization_mw
-                            else messages
-                        )
-                        self.repl.runtime.last_context_tokens = (
-                            count_tokens_approximately(effective)
-                        )
-                        for msg in messages:
-                            role = getattr(msg, "type", "unknown")
-                            content = extract_text(getattr(msg, "content", ""))
-                            if not content:
-                                continue
-                            if role in ("human", "user"):
-                                scroll.mount(UserMessage(content))
-                            elif role in ("ai", "assistant"):
-                                scroll.mount(AgentResponse(initial_text=content))
+                messages = await self.repl.runtime.get_thread_messages(resolved)
+                self.repl.runtime.last_context_tokens = (
+                    await self.repl.runtime.count_effective_tokens(resolved)
+                )
+                for msg in messages:
+                    role = getattr(msg, "type", "unknown")
+                    content = extract_text(getattr(msg, "content", ""))
+                    if not content:
+                        continue
+                    if role in ("human", "user"):
+                        scroll.mount(UserMessage(content))
+                    elif role in ("ai", "assistant"):
+                        scroll.mount(AgentResponse(initial_text=content))
                 scroll.mount(SystemMessage(f"[bold #38bdf8]✓ {_('Resumed session: {session_id}', session_id=f'{resolved[:8]} ({resolved})')}[/bold #38bdf8]"))
                 self.query_one(AgentHeader).update_header()
                 self._deferred_scroll()
@@ -636,12 +636,17 @@ class OllamaAgentApp(App):
             return
 
         if cmd == "/session" and args and args[0] == "export":
-            out_file = await export_session(
-                self.repl.console,
-                self.repl.runtime,
-                self.repl.runtime.thread_id,
-                output_path=args[1] if len(args) > 1 else None,
-            )
+            try:
+                out_file = await export_session(
+                    self.repl.console,
+                    self.repl.runtime,
+                    self.repl.runtime.thread_id,
+                    output_path=args[1] if len(args) > 1 else None,
+                )
+            except HistoryError as exc:
+                scroll.mount(SystemMessage(f"[red]{exc}[/red]"))
+                self._deferred_scroll()
+                return
             if out_file:
                 scroll.mount(SystemMessage(f"[bold #38bdf8]✓ {_('Session exported to: {path}', path=out_file)}[/bold #38bdf8]"))
             else:
@@ -704,7 +709,7 @@ class OllamaAgentApp(App):
                 return
             try:
                 tid, t = self.repl._task_ctx._find_or_exit(target_id)
-            except (TaskError, SystemExit) as exc:
+            except TaskError as exc:
                 scroll.mount(SystemMessage(f"[red]{exc}[/red]"))
                 self._deferred_scroll()
                 return
@@ -733,10 +738,10 @@ class OllamaAgentApp(App):
 
         spec = commands[cmd]
         scroll_w = scroll.size.width if scroll.size.width > 10 else self.size.width
-        self.repl.console._width = max(40, scroll_w - 6)
-        self.repl.console._height = 25
+        self.repl.console.width = max(40, scroll_w - 6)
+        self.repl.console.height = 25
         with self.repl.console.capture() as capture:
-            await safe_call(spec.handler, args)
+            await safe_call(spec.handler, args, console=self.repl.console)
         output = capture.get()
         if output:
             scroll.mount(SystemMessage(Text.from_ansi(output)))
@@ -884,10 +889,7 @@ class OllamaREPL:
     async def run(self) -> None:
         rag_ctx = self._get_rag_ctx()
         if self._initial_rag_database:
-            try:
-                load_rag_database(rag_ctx, self._initial_rag_database)
-            except SystemExit:
-                pass
+            load_rag_database(rag_ctx, self._initial_rag_database)
 
         set_tool_timeout(self.runtime.settings.runtime.builtin_tool_timeout)
         await self.runtime.reload()

--- a/ollama_agent/interfaces/session_commands.py
+++ b/ollama_agent/interfaces/session_commands.py
@@ -13,7 +13,11 @@ from rich.table import Table
 
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
-from ..agent.episodic_memory import format_iso_timestamp, search_past_conversations_in_db
+from ..agent.episodic_memory import (
+    connect_history,
+    format_iso_timestamp,
+    search_past_conversations_in_db,
+)
 from ..core.common import extract_text
 from ..i18n import _
 from ..settings.paths import HISTORY_DB_PATH
@@ -40,32 +44,29 @@ def get_available_sessions(db_path: Path = HISTORY_DB_PATH) -> list[dict[str, An
     if not db_path.exists():
         return []
 
-    try:
-        with sqlite3.connect(str(db_path)) as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT thread_id, type, checkpoint FROM checkpoints ORDER BY rowid ASC"
-            )
-            timestamps: dict[str, str] = {}
-            for tid, typ, chk in cursor.fetchall():
-                c = _serializer.loads_typed((typ, chk))
-                if isinstance(c, dict) and "ts" in c:
-                    timestamps[tid] = str(c["ts"])
+    with connect_history(db_path) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT thread_id, type, checkpoint FROM checkpoints ORDER BY rowid ASC"
+        )
+        timestamps: dict[str, str] = {}
+        for tid, typ, chk in cursor.fetchall():
+            c = _serializer.loads_typed((typ, chk))
+            if isinstance(c, dict) and "ts" in c:
+                timestamps[tid] = str(c["ts"])
 
-            cursor.execute(
-                "SELECT thread_id, COUNT(*) as steps FROM checkpoints GROUP BY thread_id ORDER BY MAX(rowid) DESC"
-            )
-            rows = cursor.fetchall()
-            return [
-                {
-                    "thread_id": row[0],
-                    "steps": row[1],
-                    "timestamp": format_iso_timestamp(timestamps.get(row[0], "")),
-                }
-                for row in rows
-            ]
-    except (sqlite3.Error, OSError):
-        return []
+        cursor.execute(
+            "SELECT thread_id, COUNT(*) as steps FROM checkpoints GROUP BY thread_id ORDER BY MAX(rowid) DESC"
+        )
+        rows = cursor.fetchall()
+        return [
+            {
+                "thread_id": row[0],
+                "steps": row[1],
+                "timestamp": format_iso_timestamp(timestamps.get(row[0], "")),
+            }
+            for row in rows
+        ]
 
 
 def list_sessions(
@@ -184,15 +185,7 @@ async def export_session(
     sessions = get_available_sessions(db_path)
     resolved = resolve_session_id(target_id, sessions) or target_id
 
-    if runtime.graph is None:
-        await runtime.reload()
-    if runtime.graph is None:
-        console.print(f"[red]{_('Agent runtime graph could not be initialized.')}[/red]")
-        return None
-
-    config = {"configurable": {"thread_id": resolved}}
-    state = await runtime.graph.aget_state(config)
-    messages = state.values.get("messages", []) if state and state.values else []
+    messages = await runtime.get_thread_messages(resolved)
 
     if not messages:
         no_msgs = _("No messages found for session '{resolved}'.", resolved=resolved)

--- a/ollama_agent/interfaces/tui_components.py
+++ b/ollama_agent/interfaces/tui_components.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -10,13 +11,15 @@ from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
 from textual.message import Message
 from textual.timer import Timer
-from textual.widgets import Button, Collapsible, Label, Markdown, OptionList, Static, TextArea
+from textual.widgets import Button, Collapsible, Markdown, OptionList, Static, TextArea
 
-from ..agent.episodic_memory import load_past_user_prompts
+from ..agent.episodic_memory import HistoryError, load_past_user_prompts
 from ..i18n import _
 
 if TYPE_CHECKING:
     from .repl import OllamaREPL, OllamaAgentApp
+
+_log = logging.getLogger(__name__)
 
 
 # ─── Header ──────────────────────────────────────────────────────────────────
@@ -152,7 +155,11 @@ class ReplInput(TextArea):
         self._update_height()
 
     async def _load_history(self) -> None:
-        db_entries = await asyncio.to_thread(load_past_user_prompts)
+        try:
+            db_entries = await asyncio.to_thread(load_past_user_prompts)
+        except HistoryError as exc:
+            _log.warning("Prompt history unavailable: %s", exc)
+            db_entries = []
         self._history = list(db_entries)
         self._history_index = len(self._history)
         self._temp_input = ""

--- a/ollama_agent/main.py
+++ b/ollama_agent/main.py
@@ -15,12 +15,12 @@ from .interfaces.model_commands import ensure_model_configured
 from .interfaces.repl import OllamaREPL
 from .settings import load_settings, reset_config
 
+# Silence only the known third-party noise, not all deprecations.
 warnings.filterwarnings(
     "ignore",
     category=LangChainPendingDeprecationWarning,
     message=".*allowed_objects.*",
 )
-warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
 def main() -> None:

--- a/ollama_agent/mcp/__init__.py
+++ b/ollama_agent/mcp/__init__.py
@@ -1,9 +1,15 @@
 """MCP servers configuration and lifecycle management."""
 
 from .commands import MCPServerStatus, check_mcp_server, list_mcp_servers
-from .loader import get_mcp_config_path, load_main_mcp_tools, load_subagent_mcp_tools
+from .loader import (
+    MCPConfigError,
+    get_mcp_config_path,
+    load_main_mcp_tools,
+    load_subagent_mcp_tools,
+)
 
 __all__ = [
+    "MCPConfigError",
     "MCPServerStatus",
     "check_mcp_server",
     "get_mcp_config_path",

--- a/ollama_agent/mcp/loader.py
+++ b/ollama_agent/mcp/loader.py
@@ -12,10 +12,14 @@ from typing import Any
 
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
+from ..i18n import _
 from ..settings import MCP_PATH, MCP_SERVERS_PATH, SubAgentMCPServer
-
 _log = logging.getLogger(__name__)
 _ENV_RE = re.compile(r"\$\{([^}]+)\}|%([^%]+)%")
+
+
+class MCPConfigError(RuntimeError):
+    """Raised when the MCP configuration file is unreadable or invalid."""
 
 
 def get_mcp_config_path() -> Path:
@@ -86,7 +90,10 @@ def _build_mcp_connection(cfg: dict[str, Any]) -> dict[str, Any] | None:
 
 
 async def load_main_mcp_tools() -> list[Any]:
-    """Load flat MCP tools for the main agent from mcp.json / mcp_servers.json."""
+    """Load flat MCP tools for the main agent from mcp.json / mcp_servers.json.
+
+    Raises MCPConfigError when the config file exists but cannot be parsed.
+    """
     config_path = get_mcp_config_path()
     if not config_path.exists():
         return []
@@ -95,8 +102,14 @@ async def load_main_mcp_tools() -> list[Any]:
         raw_json = await asyncio.to_thread(config_path.read_text, encoding="utf-8")
         data = json.loads(raw_json)
     except (json.JSONDecodeError, OSError) as exc:
-        _log.error("Failed to load MCP config %s: %s", config_path, exc)
-        return []
+        raise MCPConfigError(
+            _("Failed to load MCP config {config_path}: {exc}", config_path=config_path, exc=exc)
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise MCPConfigError(
+            _("Invalid MCP config {config_path}: expected a JSON object", config_path=config_path)
+        )
 
     servers_cfg = data.get("mcpServers") or data.get("servers") or {}
     if not isinstance(servers_cfg, dict) or not servers_cfg:

--- a/ollama_agent/rag/manager.py
+++ b/ollama_agent/rag/manager.py
@@ -16,7 +16,6 @@ from qdrant_client.models import (
     FieldCondition,
     Filter,
     MatchAny,
-    MatchValue,
     PointStruct,
     VectorParams,
 )
@@ -262,19 +261,8 @@ class RAGManager:
         if not valid_files:
             return results
 
-        # Delete existing points for all valid files in a single operation
-        filt = Filter(
-            must=[FieldCondition(key="source", match=MatchAny(any=valid_files))]
-        )
-        try:
-            client.delete(
-                collection_name=self.COLLECTION_NAME, points_selector=filt, wait=True
-            )
-        except Exception as e:
-            logger.warning(
-                "Failed to delete existing points for directory batch: %s", e
-            )
-            raise RAGError(_("Failed to clear existing points for directory batch: {e}", e=e)) from e
+        if not valid_files:
+            return results
 
         # Prepare a flat list of chunk data
         flat_chunks_data = []
@@ -285,43 +273,47 @@ class RAGManager:
             for i, chunk in enumerate(chunks):
                 flat_chunks_data.append((source, fname, chunk, i, total_chunks))
 
-        # Process in batches
+        # Process in batches. Old points are deleted only after the batch
+        # embeddings succeed, so a failure never loses already-indexed content.
         BATCH_SIZE = 100
         failed_sources: set[str] = set()
         for i in range(0, len(flat_chunks_data), BATCH_SIZE):
             batch = flat_chunks_data[i : i + BATCH_SIZE]
             batch_texts = [b[2] for b in batch]
+            batch_sources = {b[0] for b in batch}
             try:
                 embeddings = await self._get_embeddings(batch_texts)
-                points = []
-                for (
-                    (source, fname, chunk, chunk_idx, total_chunks),
-                    embedding,
-                ) in zip(batch, embeddings, strict=True):
-                    point_id = self._generate_point_id(source, chunk_idx)
-                    points.append(
-                        PointStruct(
-                            id=point_id,
-                            vector=embedding,
-                            payload={
-                                "content": chunk,
-                                "source": source,
-                                "filename": fname,
-                                "chunk_index": chunk_idx,
-                                "total_chunks": total_chunks,
-                            },
-                        )
-                    )
-                if points:
-                    client.upsert(collection_name=self.COLLECTION_NAME, points=points)
-            except Exception as e:
+            except RAGError as e:
                 logger.warning(
-                    "Failed to process batch embeddings/upsert starting at index %d: %s",
+                    "Failed to generate embeddings for batch starting at index %d: %s",
                     i,
                     e,
                 )
-                for source, *_rest in batch:
-                    failed_sources.add(source)
+                failed_sources.update(batch_sources)
+                continue
+
+            self._delete_sources_points(client, batch_sources)
+
+            points = []
+            for (
+                (source, fname, chunk, chunk_idx, total_chunks),
+                embedding,
+            ) in zip(batch, embeddings, strict=True):
+                point_id = self._generate_point_id(source, chunk_idx)
+                points.append(
+                    PointStruct(
+                        id=point_id,
+                        vector=embedding,
+                        payload={
+                            "content": chunk,
+                            "source": source,
+                            "filename": fname,
+                            "chunk_index": chunk_idx,
+                            "total_chunks": total_chunks,
+                        },
+                    )
+                )
+            client.upsert(collection_name=self.COLLECTION_NAME, points=points)
 
         # Populate results for successful files
         for fpath, chunks in all_file_chunks:
@@ -412,8 +404,12 @@ class RAGManager:
 
     def _delete_source_points(self, client: QdrantClient, source: str) -> None:
         """Delete all points previously indexed for a given source path."""
+        self._delete_sources_points(client, {source})
+
+    def _delete_sources_points(self, client: QdrantClient, sources: set[str]) -> None:
+        """Delete all points previously indexed for the given source paths."""
         filt = Filter(
-            must=[FieldCondition(key="source", match=MatchValue(value=source))]
+            must=[FieldCondition(key="source", match=MatchAny(any=sorted(sources)))]
         )
         try:
             client.delete(
@@ -421,7 +417,7 @@ class RAGManager:
             )
         except Exception as e:
             raise RAGError(
-                _("Failed to delete existing points for source '{source}': {e}", source=source, e=e)
+                _("Failed to delete existing points for source '{source}': {e}", source=sorted(sources)[0], e=e)
             ) from e
 
     def _chunk_text(self, text: str) -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,20 @@ dependencies = [
 [project.scripts]
 ollama-agent = "ollama_agent.main:main"
 
+[project.optional-dependencies]
+dev = ["ruff>=0.9"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["ollama_agent*"]
 
 [tool.setuptools.package-data]
 ollama_agent = ["settings/prompts/*.md", "interfaces/*.css", "i18n/locales/*.json"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -327,22 +327,20 @@ class TestAgentRuntimeComponents(unittest.IsolatedAsyncioTestCase):
     async def test_compact_context_empty_or_too_few(self) -> None:
         settings = Settings()
         runtime = AgentRuntime(settings=settings)
+        runtime._model = MagicMock()
         mock_graph = MagicMock()
         mock_state_empty = MagicMock(values={})
         mock_graph.aget_state = AsyncMock(return_value=mock_state_empty)
         runtime.graph = mock_graph
-        runtime._summarization_mw = MagicMock()
-        runtime._backend = MagicMock()
 
         # Empty messages
         res = await runtime.compact_context("thread-1")
         self.assertFalse(res["success"])
         self.assertIn("No messages", res["message"])
 
-        # 1 message (< 2)
-        mock_state_single = MagicMock(values={"messages": [MagicMock(content="hello")]})
+        # 1 message (< keep threshold)
+        mock_state_single = MagicMock(values={"messages": [HumanMessage(content="hello")]})
         mock_graph.aget_state = AsyncMock(return_value=mock_state_single)
-        runtime._summarization_mw._apply_event_to_messages.return_value = [MagicMock(content="hello")]
         res2 = await runtime.compact_context("thread-1")
         self.assertFalse(res2["success"])
         self.assertIn("Not enough messages", res2["message"])
@@ -350,40 +348,93 @@ class TestAgentRuntimeComponents(unittest.IsolatedAsyncioTestCase):
     async def test_compact_context_success(self) -> None:
         settings = Settings()
         runtime = AgentRuntime(settings=settings)
-        mock_graph = MagicMock()
+        runtime._backend = MagicMock()
+        runtime._model = MagicMock()
+
         msg1 = HumanMessage(content="First prompt")
-        msg2 = AIMessage(content="First answer")
+        msg2 = AIMessage(content="First answer", tool_calls=[])
         msg3 = HumanMessage(content="Second prompt")
         msg4 = AIMessage(content="Second answer")
 
-        mock_state = MagicMock(values={"messages": [msg1, msg2, msg3, msg4], "_summarization_event": None})
+        mock_state = MagicMock(
+            values={
+                "messages": [msg1, msg2, msg3, msg4],
+                "_summarization_event": None,
+            }
+        )
+        mock_graph = MagicMock()
         mock_graph.aget_state = AsyncMock(return_value=mock_state)
         mock_graph.aupdate_state = AsyncMock()
         runtime.graph = mock_graph
 
-        mock_mw = MagicMock()
-        mock_mw._apply_event_to_messages.return_value = [msg1, msg2, msg3, msg4]
-        mock_mw._determine_cutoff_index.return_value = 2
-        mock_mw._partition_messages.return_value = ([msg1, msg2], [msg3, msg4])
-        mock_mw._aoffload_to_backend = AsyncMock(return_value="/conversation_history/thread-1.md")
-        mock_mw._acreate_summary = AsyncMock(return_value="Summary of first turn")
-        summary_human_msg = HumanMessage(content="Condensed summary")
-        mock_mw._build_new_messages_with_path.return_value = [summary_human_msg]
-        mock_mw._compute_state_cutoff.return_value = 2
+        async def fake_summary(model: Any, messages: list[Any]) -> str:
+            self.assertEqual(messages, [msg1, msg2])
+            return "Summary of first turn"
 
-        runtime._summarization_mw = mock_mw
-        runtime._backend = MagicMock()
+        async def fake_offload(backend: Any, messages: list[Any], path: str) -> str | None:
+            self.assertEqual(messages, [msg1, msg2])
+            return "/conversation_history/session-abc.md"
 
-        res = await runtime.compact_context("thread-1")
+        with patch("ollama_agent.agent.agent.generate_summary", side_effect=fake_summary), \
+             patch("ollama_agent.agent.agent.offload_history", side_effect=fake_offload):
+            res = await runtime.compact_context("thread-1")
+
         self.assertTrue(res["success"])
         self.assertEqual(res["messages_summarized"], 2)
         self.assertEqual(res["messages_preserved"], 2)
-        self.assertEqual(res["file_path"], "/conversation_history/thread-1.md")
+        self.assertEqual(res["file_path"], "/conversation_history/session-abc.md")
         self.assertEqual(res["summary"], "Summary of first turn")
 
         mock_graph.aupdate_state.assert_awaited_once()
         update_call = mock_graph.aupdate_state.call_args
         self.assertEqual(update_call[0][0], {"configurable": {"thread_id": "thread-1"}})
-        self.assertEqual(update_call[0][1]["_summarization_event"]["cutoff_index"], 2)
+        new_event = update_call[0][1]["_summarization_event"]
+        self.assertEqual(new_event["cutoff_index"], 2)
+        self.assertEqual(new_event["file_path"], "/conversation_history/session-abc.md")
+        self.assertIn("session-abc.md", new_event["summary_message"].content)
         self.assertGreater(runtime.last_context_tokens, 0)
+
+    async def test_compact_context_chained_prior_event(self) -> None:
+        """A second compaction must translate the cutoff to absolute state index."""
+        settings = Settings()
+        runtime = AgentRuntime(settings=settings)
+        runtime._backend = MagicMock()
+        runtime._model = MagicMock()
+
+        prior_summary = HumanMessage(
+            content="prior summary", additional_kwargs={"lc_source": "summarization"}
+        )
+        msg3 = HumanMessage(content="Third prompt")
+        msg4 = AIMessage(content="Third answer")
+        msg5 = HumanMessage(content="Fourth prompt")
+        msg6 = AIMessage(content="Fourth answer")
+
+        prior_event = {
+            "cutoff_index": 2,
+            "summary_message": prior_summary,
+            "file_path": "/conversation_history/s.md",
+        }
+        mock_state = MagicMock(
+            values={
+                # Raw state: [old1, old2, summary, msg3..msg6]; effective starts at the summary.
+                "messages": ["old1", "old2", prior_summary, msg3, msg4, msg5, msg6],
+                "_summarization_event": prior_event,
+                "_summarization_session_id": "session_fixed",
+            }
+        )
+        mock_graph = MagicMock()
+        mock_graph.aget_state = AsyncMock(return_value=mock_state)
+        mock_graph.aupdate_state = AsyncMock()
+        runtime.graph = mock_graph
+
+        with patch("ollama_agent.agent.agent.generate_summary", AsyncMock(return_value="new summary")), \
+             patch("ollama_agent.agent.agent.offload_history", AsyncMock(return_value=None)):
+            res = await runtime.compact_context("t")
+
+        self.assertTrue(res["success"])
+        # Effective = [prior_summary, summary, msg3, msg4, msg5, msg6]; keep 2
+        # -> effective cutoff 4; absolute = 2 + 4 - 1 = 5
+        new_event = mock_graph.aupdate_state.call_args[0][1]["_summarization_event"]
+        self.assertEqual(new_event["cutoff_index"], 5)
+        self.assertIsNone(new_event["file_path"])
 

--- a/tests/test_clipboard.py
+++ b/tests/test_clipboard.py
@@ -7,7 +7,7 @@ from textual import events
 
 from ollama_agent.interfaces.clipboard import copy_to_system_clipboard, get_system_clipboard
 from ollama_agent.interfaces.repl import OllamaAgentApp, OllamaREPL
-from ollama_agent.interfaces.tui_components import ReplInput, UserMessage
+from ollama_agent.interfaces.tui_components import UserMessage
 
 
 class TestClipboard(unittest.TestCase):
@@ -55,7 +55,11 @@ class TestClipboard(unittest.TestCase):
         mock_k32.GlobalAlloc.return_value = 12345
         mock_k32.GlobalLock.return_value = 67890
 
-        copy_to_system_clipboard("hello windows")
+        # memmove must be mocked: the mocked GlobalLock returns a plain int,
+        # and writing to it as a pointer would segfault the interpreter.
+        with patch("ctypes.memmove") as mock_memmove:
+            copy_to_system_clipboard("hello windows")
+            mock_memmove.assert_called_once()
         mock_u32.OpenClipboard.assert_called_once_with(None)
         mock_u32.EmptyClipboard.assert_called_once()
         mock_u32.SetClipboardData.assert_called_once_with(13, 12345)
@@ -104,7 +108,7 @@ class TestAppClipboardIntegration(unittest.IsolatedAsyncioTestCase):
 
         app = OllamaAgentApp(repl_mock)
         with patch("ollama_agent.interfaces.repl.copy_to_system_clipboard") as mock_sys_copy:
-            async with app.run_test() as pilot:
+            async with app.run_test():
                 app.copy_to_clipboard("test copy content")
                 mock_sys_copy.assert_called_once_with("test copy content")
                 self.assertEqual(app._clipboard, "test copy content")
@@ -162,9 +166,9 @@ class TestAppClipboardIntegration(unittest.IsolatedAsyncioTestCase):
         repl_mock.runtime.settings.model.reasoning_effort = "medium"
 
         app = OllamaAgentApp(repl_mock)
-        async with app.run_test() as pilot:
+        async with app.run_test():
             event = events.MouseDown(None, 5, 5, 0, 0, 1, False, False, False)
-            with patch("ollama_agent.interfaces.repl._original_screen_forward_event", side_effect=AttributeError("'NoneType' object has no attribute 'region'")):
+            with patch("textual.screen.Screen._forward_event", side_effect=AttributeError("'NoneType' object has no attribute 'region'")):
                 app.screen._forward_event(event)
                 self.assertIsNone(app.screen._select_state)
 
@@ -177,9 +181,9 @@ class TestAppClipboardIntegration(unittest.IsolatedAsyncioTestCase):
         repl_mock.runtime.settings.model.reasoning_effort = "medium"
 
         app = OllamaAgentApp(repl_mock)
-        async with app.run_test() as pilot:
+        async with app.run_test():
             event = events.MouseDown(None, 5, 5, 0, 0, 1, False, False, False)
-            with patch("ollama_agent.interfaces.repl._original_screen_forward_event", side_effect=AttributeError("'CustomType' object has no attribute 'something_else'")):
+            with patch("textual.screen.Screen._forward_event", side_effect=AttributeError("'CustomType' object has no attribute 'something_else'")):
                 with self.assertRaises(AttributeError):
                     app.screen._forward_event(event)
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import unittest
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from ollama_agent.agent.compaction import (
+    apply_summarization_event,
+    build_summary_message,
+    compute_state_cutoff,
+    find_safe_cutoff,
+    is_summary_message,
+)
+
+
+def _tool_call_msg(call_id: str = "call-1") -> AIMessage:
+    return AIMessage(content="", tool_calls=[{"name": "run", "args": {}, "id": call_id}])
+
+
+class TestApplySummarizationEvent(unittest.TestCase):
+    def test_none_event_returns_full_list(self) -> None:
+        msgs = [HumanMessage(content="a"), AIMessage(content="b")]
+        self.assertEqual(apply_summarization_event(msgs, None), msgs)
+
+    def test_event_slices_messages(self) -> None:
+        summary = HumanMessage(content="s")
+        msgs = ["old1", "old2", HumanMessage(content="new")]
+        event = {"cutoff_index": 2, "summary_message": summary, "file_path": None}
+        self.assertEqual(
+            apply_summarization_event(msgs, event),
+            [summary, msgs[2]],
+        )
+
+    def test_malformed_event_falls_back_to_full_list(self) -> None:
+        msgs = [HumanMessage(content="a")]
+        self.assertEqual(apply_summarization_event(msgs, {"bogus": 1}), msgs)
+
+    def test_out_of_bounds_cutoff_returns_summary_only(self) -> None:
+        summary = HumanMessage(content="s")
+        event = {"cutoff_index": 10, "summary_message": summary, "file_path": None}
+        self.assertEqual(apply_summarization_event(["a"], event), [summary])
+
+
+class TestCutoff(unittest.TestCase):
+    def test_not_enough_messages(self) -> None:
+        self.assertEqual(find_safe_cutoff([HumanMessage(content="a")], keep=2), 0)
+        self.assertEqual(find_safe_cutoff([], keep=2), 0)
+
+    def test_simple_cut(self) -> None:
+        msgs = [HumanMessage("1"), AIMessage("2"), HumanMessage("3"), AIMessage("4")]
+        self.assertEqual(find_safe_cutoff(msgs, keep=2), 2)
+
+    def test_cut_never_orphans_tool_messages(self) -> None:
+        # target=2 lands on the ToolMessage; cutoff must move back to the AIMessage
+        msgs = [
+            HumanMessage("q"),
+            _tool_call_msg("call-1"),
+            ToolMessage(content="out", tool_call_id="call-1"),
+            AIMessage("done"),
+            HumanMessage("next"),
+        ]
+        self.assertEqual(find_safe_cutoff(msgs, keep=3), 1)
+
+    def test_cut_advances_past_orphan_tool_messages(self) -> None:
+        # ToolMessage at target with no matching AIMessage in range
+        msgs = [HumanMessage("q"), ToolMessage(content="out", tool_call_id="x"), AIMessage("a")]
+        self.assertEqual(find_safe_cutoff(msgs, keep=2), 2)
+
+
+class TestStateCutoff(unittest.TestCase):
+    def test_no_prior_event(self) -> None:
+        self.assertEqual(compute_state_cutoff(None, 3), 3)
+
+    def test_prior_event_adjusts_for_summary_slot(self) -> None:
+        prior = {"cutoff_index": 2, "summary_message": HumanMessage("s"), "file_path": None}
+        self.assertEqual(compute_state_cutoff(prior, 3), 4)
+
+    def test_malformed_prior_event(self) -> None:
+        self.assertEqual(compute_state_cutoff({"nope": 1}, 3), 3)
+
+
+class TestSummaryMessage(unittest.TestCase):
+    def test_with_file_path(self) -> None:
+        msg = build_summary_message("the summary", "/conversation_history/s.md")
+        self.assertTrue(is_summary_message(msg))
+        self.assertIn("/conversation_history/s.md", msg.content)
+        self.assertIn("the summary", msg.content)
+
+    def test_without_file_path(self) -> None:
+        msg = build_summary_message("the summary", None)
+        self.assertIn("the summary", msg.content)
+        self.assertNotIn("<summary>", msg.content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,9 +8,7 @@ from unittest.mock import patch
 
 from ollama_agent.settings.config import (
     LangSmithSettings,
-    MentionSettings,
     ModelSettings,
-    RAGSettings,
     RuntimeSettings,
     Settings,
     SubAgentMCPServer,

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-import argparse
 import io
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from rich.console import Console
 
-from ollama_agent.core import ModelCapabilityError, ModelContextWindowError
+from ollama_agent.core import ModelCapabilityError
 from ollama_agent.interfaces.cli import create_argument_parser
 from ollama_agent.interfaces.dispatch import (
     REPL_SECTIONS,
@@ -114,7 +113,9 @@ class TestDispatchAndCLI(unittest.TestCase):
             self.assertIn(cmd.section, REPL_SECTIONS)
 
     def test_main_config_reset(self) -> None:
+        # Patch set_locale so the system language does not leak into other tests.
         with patch("sys.argv", ["ollama-agent", "--config-reset", "config-file"]), \
+             patch("ollama_agent.main.set_locale", return_value="en"), \
              patch("ollama_agent.main.reset_config", return_value=["Reset successful"]) as mock_reset, \
              patch("builtins.print") as mock_print:
             main()
@@ -123,6 +124,7 @@ class TestDispatchAndCLI(unittest.TestCase):
 
     def test_main_cli_commands_handled(self) -> None:
         with patch("sys.argv", ["ollama-agent", "task", "list"]), \
+             patch("ollama_agent.main.set_locale", return_value="en"), \
              patch("ollama_agent.main.load_settings", return_value=Settings()), \
              patch("ollama_agent.main.handle_cli_commands", return_value=True) as mock_handle:
             main()
@@ -131,6 +133,7 @@ class TestDispatchAndCLI(unittest.TestCase):
     def test_main_repl_flow(self) -> None:
         mock_settings = Settings()
         with patch("sys.argv", ["ollama-agent", "-m", "qwen3:32b", "-e", "high", "--builtin-tool-timeout", "40"]), \
+             patch("ollama_agent.main.set_locale", return_value="en"), \
              patch("ollama_agent.main.load_settings", return_value=mock_settings), \
              patch("ollama_agent.main.ensure_model_configured", return_value="qwen3:32b") as mock_ensure, \
              patch("ollama_agent.main.handle_cli_commands", return_value=False), \
@@ -148,6 +151,7 @@ class TestDispatchAndCLI(unittest.TestCase):
 
     def test_main_model_capability_error_exits(self) -> None:
         with patch("sys.argv", ["ollama-agent"]), \
+             patch("ollama_agent.main.set_locale", return_value="en"), \
              patch("ollama_agent.main.Console"), \
              patch("ollama_agent.main.load_settings", return_value=Settings()), \
              patch("ollama_agent.main.ensure_model_configured", side_effect=ModelCapabilityError("Model unsupported")):

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -13,7 +13,6 @@ from ollama_agent.i18n import (
     detect_system_language,
     get_locale,
     get_supported_locales,
-    get_text,
     set_locale,
 )
 from ollama_agent.interfaces.cli import create_argument_parser
@@ -149,7 +148,7 @@ class TestI18nTranslations(unittest.TestCase):
     def test_italian_translation(self) -> None:
         set_locale("it")
         self.assertEqual(_("Manage saved tasks"), "Gestisci le attività salvate")
-        self.assertEqual(_("Exit the REPL"), "Esci dal REPL")
+        self.assertEqual(_("Exit the REPL"), "Uscire dalla REPL")
         self.assertEqual(_("Tool:"), "Strumento:")
         self.assertEqual(_("Arguments:"), "Argomenti:")
 

--- a/tests/test_interfaces_commands.py
+++ b/tests/test_interfaces_commands.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from rich.console import Console
 
+from ollama_agent.agent.episodic_memory import HistoryError
 from ollama_agent.core.models import ModelCapabilityError
 from ollama_agent.interfaces.cli import handle_cli_commands
 from ollama_agent.interfaces.dispatch import build_repl_handlers, safe_call
@@ -51,13 +52,21 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(called_async)
 
     async def test_safe_call_silences_expected_errors(self) -> None:
-        def raise_exit() -> None:
-            raise SystemExit(1)
-        await safe_call(raise_exit)  # Should not raise
-
         def raise_skill_error() -> None:
             raise SkillError("Skill failed")
         await safe_call(raise_skill_error)  # Should not raise
+
+        def raise_history_error() -> None:
+            raise HistoryError("History DB broken")
+        console = Console(file=io.StringIO(), record=True)
+        await safe_call(raise_history_error, console=console)  # Should not raise
+        self.assertIn("History DB broken", console.export_text())
+
+    async def test_safe_call_propagates_unexpected_errors(self) -> None:
+        def raise_exit() -> None:
+            raise SystemExit(1)
+        with self.assertRaises(SystemExit):
+            await safe_call(raise_exit)
 
     async def test_list_models_empty(self) -> None:
         console = Console(file=io.StringIO(), record=True)
@@ -219,6 +228,7 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
         runtime.effective_model_params = {
             "temperature": (0.8, "default"),
         }
+        switch_mock = AsyncMock()
 
         handlers = build_repl_handlers(
             task_ctx=MagicMock(),
@@ -227,7 +237,7 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
             console=console,
             current_model=lambda: "llama3.2:3b",
             base_url=lambda: "http://localhost:11434",
-            switch_model=AsyncMock(),
+            switch_model=switch_mock,
             handle_exit=lambda _: None,
             handle_new=AsyncMock(),
             handle_task_create=lambda _: None,
@@ -241,23 +251,18 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
         out = console.export_text()
         self.assertIn("Active Model Parameters", out)
 
-        # /params list
-        console = Console(file=io.StringIO(), record=True)
+        # /params list (handlers print to the console they were built with,
+        # so all following assertions check the accumulated output)
         handlers["/params"].handler(["list"])
-        out_list = console.export_text()
-        self.assertIn("Active Model Parameters", out_list)
+        self.assertIn("Active Model Parameters", console.export_text())
 
         # /params set with missing args
-        console = Console(file=io.StringIO(), record=True)
         handlers["/params"].handler(["set", "temperature"])
-        out_missing = console.export_text()
-        self.assertIn("Usage: /params set", out_missing)
+        self.assertIn("Usage: /params set", console.export_text())
 
-        # /model does not handle params
-        console = Console(file=io.StringIO(), record=True)
-        handlers["/model"].handler(["params"])
-        out_model = console.export_text()
-        self.assertIn("Usage: /model", out_model)
+        # /model <name> routes to switch_model (single arg is treated as a model name)
+        handlers["/model"].handler(["some-model"])
+        switch_mock.assert_called_once_with("some-model")
 
     def test_effort_dispatch(self) -> None:
         console = Console(file=io.StringIO(), record=True)
@@ -325,7 +330,7 @@ class TestInterfacesCommands(unittest.IsolatedAsyncioTestCase):
         switch_model.assert_awaited_with("llama3:8b")
 
         # 1b. /effort handler
-        with patch("ollama_agent.interfaces.dispatch.show_effort") as mock_show_effort:
+        with patch("ollama_agent.interfaces.dispatch.show_effort"):
             handlers["/effort"].handler([])
             out_effort = console.export_text()
             self.assertIn("Current reasoning effort", out_effort)

--- a/tests/test_mcp_loader.py
+++ b/tests/test_mcp_loader.py
@@ -10,11 +10,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from rich.console import Console
 
 from ollama_agent.mcp.commands import (
-    MCPServerStatus,
     check_mcp_server,
     list_mcp_servers,
 )
 from ollama_agent.mcp.loader import (
+    MCPConfigError,
     _build_mcp_connection,
     _resolve_env,
     get_mcp_config_path,
@@ -139,15 +139,15 @@ class TestMCPLoader(unittest.IsolatedAsyncioTestCase):
             tools = await load_main_mcp_tools()
             self.assertEqual(tools, [])
 
-    async def test_load_main_mcp_tools_invalid_json_returns_empty(self) -> None:
+    async def test_load_main_mcp_tools_invalid_json_raises(self) -> None:
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as tmp:
             tmp.write("{invalid-json")
             tmp_path = Path(tmp.name)
 
         try:
             with patch("ollama_agent.mcp.loader.get_mcp_config_path", return_value=tmp_path):
-                tools = await load_main_mcp_tools()
-                self.assertEqual(tools, [])
+                with self.assertRaises(MCPConfigError):
+                    await load_main_mcp_tools()
         finally:
             tmp_path.unlink(missing_ok=True)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -191,9 +191,11 @@ class TestModelsLogic(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ModelContextWindowError):
             await resolve_context_window("unknown-model", "max", "http://localhost:11434")
 
+    @patch("ollama_agent.core.models._show_model")
     @patch("ollama_agent.core.models.resolve_context_window", AsyncMock(return_value=8192))
     @patch("ollama_agent.core.models.resolve_ollama_reasoning", AsyncMock(return_value=True))
-    async def test_create_ollama_chat_model(self) -> None:
+    async def test_create_ollama_chat_model(self, mock_show: AsyncMock) -> None:
+        mock_show.return_value = MagicMock(parameters="", modelfile="")
         model = await create_ollama_chat_model(
             model="gemma4:26b",
             base_url="http://localhost:11434",

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -5,7 +5,6 @@ import unittest
 from pathlib import Path
 
 from ollama_agent.rag import (
-    AmbiguousRAGDatabaseError,
     RAGContext,
     RAGDatabaseNotFoundError,
     RAGError,

--- a/tests/test_rag_manager.py
+++ b/tests/test_rag_manager.py
@@ -12,7 +12,6 @@ from ollama_agent.rag.commands import (
     AmbiguousRAGDatabaseError,
     RAGContext,
     RAGDatabaseNotFoundError,
-    add_rag_file,
     create_rag_database,
     delete_rag_database,
     list_rag_databases,
@@ -167,8 +166,9 @@ class TestRAGManagerAndCommands(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(RAGError):
             await self.manager.add_directory(str(f1))
 
-        # Batch failure during add_directory
-        with patch.object(RAGManager, "_get_embeddings", AsyncMock(side_effect=RuntimeError("Ollama connection failed"))):
+        # Batch failure during add_directory: embeddings raise before any
+        # deletion happens, so no indexed content is lost.
+        with patch.object(RAGManager, "_get_embeddings", AsyncMock(side_effect=RAGError("Ollama connection failed"))):
             res = await self.manager.add_directory(str(sub_dir))
             self.assertEqual(res["added"], 0)
             self.assertEqual(res["failed"], 2)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -23,6 +23,8 @@ from ollama_agent.interfaces.session_commands import (
     search_sessions,
 )
 
+_serializer = JsonPlusSerializer()
+
 
 class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
     """Unit tests for session management and persistence."""
@@ -35,13 +37,46 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         self.tmpdir.cleanup()
 
     def _init_sample_db(self) -> None:
+        """Create a history DB matching the langgraph AsyncSqliteSaver schema."""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
-        cursor.execute("CREATE TABLE checkpoints (thread_id TEXT, checkpoint_id TEXT, checkpoint BLOB);")
-        cursor.execute("CREATE TABLE writes (thread_id TEXT, task_id TEXT, channel TEXT);")
-        cursor.execute("INSERT INTO checkpoints VALUES ('session-12345678', 'cp-1', 'blob');")
-        cursor.execute("INSERT INTO checkpoints VALUES ('session-12345678', 'cp-2', 'blob');")
-        cursor.execute("INSERT INTO checkpoints VALUES ('session-87654321', 'cp-3', 'blob');")
+        cursor.execute(
+            """
+            CREATE TABLE checkpoints (
+                thread_id TEXT NOT NULL,
+                checkpoint_ns TEXT NOT NULL DEFAULT '',
+                checkpoint_id TEXT,
+                parent_checkpoint_id TEXT,
+                type TEXT,
+                checkpoint BLOB,
+                metadata BLOB
+            );
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE writes (
+                thread_id TEXT NOT NULL,
+                checkpoint_ns TEXT NOT NULL DEFAULT '',
+                checkpoint_id TEXT,
+                task_id TEXT,
+                idx INTEGER,
+                channel TEXT,
+                type TEXT,
+                value BLOB
+            );
+            """
+        )
+        for tid, ts in [
+            ("session-12345678", "2026-01-01T10:00:00+00:00"),
+            ("session-12345678", "2026-01-01T10:05:00+00:00"),
+            ("session-87654321", "2026-01-02T09:00:00+00:00"),
+        ]:
+            typ, blob = _serializer.dumps_typed({"v": 1, "ts": ts})
+            cursor.execute(
+                "INSERT INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, type, checkpoint) VALUES (?, '', ?, ?, ?)",
+                (tid, f"cp-{tid}-{ts}", typ, blob),
+            )
         conn.commit()
         conn.close()
 
@@ -113,13 +148,10 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
     async def test_export_session(self) -> None:
         console = Console(file=io.StringIO(), record=True)
         runtime_mock = MagicMock()
-        runtime_mock.graph = MagicMock()
 
         human_msg = MagicMock(type="human", content="How do I create a class?")
         ai_msg = MagicMock(type="ai", content="Use `class MyClass:` syntax.")
-        mock_state = MagicMock()
-        mock_state.values = {"messages": [human_msg, ai_msg]}
-        runtime_mock.graph.aget_state = AsyncMock(return_value=mock_state)
+        runtime_mock.get_thread_messages = AsyncMock(return_value=[human_msg, ai_msg])
 
         out_file = Path(self.tmpdir.name) / "export_test.md"
         exported_path = await export_session(

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-import asyncio
 import io
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from textual import events
 from textual.app import App, ComposeResult
-from textual.widgets import Button, Input, Markdown, OptionList, Static, TextArea
+from textual.widgets import OptionList
 
 from rich.console import Console
 
@@ -108,7 +107,7 @@ class TestTUIComponents(unittest.IsolatedAsyncioTestCase):
                 yield AgentResponse()
 
         app = AgentResponseTestApp()
-        async with app.run_test() as pilot:
+        async with app.run_test():
             agent_msg = app.query_one(AgentResponse)
             self.assertIsNotNone(agent_msg)
 
@@ -234,7 +233,7 @@ class TestTUIComponents(unittest.IsolatedAsyncioTestCase):
                 yield widget
 
         app = ApprovalApp()
-        async with app.run_test() as pilot:
+        async with app.run_test():
             # Auto-focused on approve-btn
             assert app.focused is not None
             self.assertEqual(app.focused.id, "approve-btn")
@@ -248,18 +247,6 @@ class TestTUIComponents(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(decisions, [{"type": "approve"}])
 
     async def test_tool_approval_widget_navigation_and_shortcuts(self) -> None:
-        # Test button labels
-        reqs = [{"name": "write_file", "args": {"path": "test.txt"}}]
-        widget = ToolApprovalWidget(
-            action_requests=reqs,
-            app_ref=MagicMock(),
-            scroll=MagicMock(),
-            agent_msg=AgentResponse(),
-        )
-        buttons = list(widget.query(Button))
-        # Compose buttons
-        composed_buttons = [w for w in widget.compose() if isinstance(w, Button) or hasattr(w, "query")]
-
         # Test single direct shortcuts (y, n, a, c)
         for shortcut, expected_type in [
             ("y", "approve"),
@@ -281,7 +268,7 @@ class TestTUIComponents(unittest.IsolatedAsyncioTestCase):
                     yield widget
 
             app = ShortcutApp()
-            async with app.run_test() as pilot:
+            async with app.run_test():
                 widget.on_key(events.Key(shortcut, shortcut))
                 app_ref_mock._handle_approval_decision.assert_called_once()
                 decisions = app_ref_mock._handle_approval_decision.call_args[0][0]
@@ -309,26 +296,31 @@ class TestTUIComponents(unittest.IsolatedAsyncioTestCase):
 
             # Press Right arrow -> reject-btn
             widget.on_key(events.Key("right", "right"))
+            await pilot.pause()
             assert nav_app.focused is not None
             self.assertEqual(nav_app.focused.id, "reject-btn")
 
             # Press Right arrow -> allow-btn
             widget.on_key(events.Key("right", "right"))
+            await pilot.pause()
             assert nav_app.focused is not None
             self.assertEqual(nav_app.focused.id, "allow-btn")
 
             # Press Right arrow -> cancel-btn
             widget.on_key(events.Key("right", "right"))
+            await pilot.pause()
             assert nav_app.focused is not None
             self.assertEqual(nav_app.focused.id, "cancel-btn")
 
             # Press Right arrow (wrap around) -> approve-btn
             widget.on_key(events.Key("right", "right"))
+            await pilot.pause()
             assert nav_app.focused is not None
             self.assertEqual(nav_app.focused.id, "approve-btn")
 
             # Press Left arrow (wrap around) -> cancel-btn
             widget.on_key(events.Key("left", "left"))
+            await pilot.pause()
             assert nav_app.focused is not None
             self.assertEqual(nav_app.focused.id, "cancel-btn")
 
@@ -354,7 +346,7 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
         repl_mock._get_commands.return_value = {}
 
         app = OllamaAgentApp(repl_mock)
-        async with app.run_test() as pilot:
+        async with app.run_test():
             # Check widgets present
             self.assertIsNotNone(app.query_one(AgentHeader))
             self.assertIsNotNone(app.query_one(AgentFooter))
@@ -386,14 +378,14 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
         repl_mock._get_commands.return_value = {"/model": cmd_spec}
 
         app = OllamaAgentApp(repl_mock)
-        async with app.run_test() as pilot:
+        async with app.run_test():
             autolist = app.query_one("#autocomplete-list", OptionList)
             self.assertFalse(autolist.display)
 
             # Trigger autocomplete with /
             app.update_autocomplete("/m")
             self.assertTrue(autolist.display)
-            self.assertEqual(autolist.option_count, 1)
+            self.assertEqual(autolist.option_count, 2)  # /model, /mcp
 
             # Hide autocomplete
             app.hide_autocomplete()
@@ -411,7 +403,7 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
         repl_mock._get_commands.return_value = {"/model": cmd_spec}
 
         app = OllamaAgentApp(repl_mock)
-        async with app.run_test() as pilot:
+        async with app.run_test():
             inp = app.query_one(ReplInput)
             inp.text = "/mo"
             app.update_autocomplete("/mo")
@@ -438,7 +430,7 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
         repl_mock._get_rag_ctx.return_value.rag_manager = mock_rag_mgr
 
         app = OllamaAgentApp(repl_mock)
-        async with app.run_test() as pilot:
+        async with app.run_test():
             autolist = app.query_one("#autocomplete-list", OptionList)
 
             # 1. Level 1: Subcommands for /task
@@ -446,10 +438,10 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(autolist.display)
             self.assertEqual(autolist.option_count, 4)  # list, create, run, delete
 
-            # 1b. Level 1: Subcommands for /session including search
+            # 1b. Level 1: Subcommands for /session including search and switch
             app.update_autocomplete("/session ")
             self.assertTrue(autolist.display)
-            self.assertEqual(autolist.option_count, 6)  # list, search, resume, new, export, delete
+            self.assertEqual(autolist.option_count, 7)  # list, search, resume, switch, new, export, delete
 
             app.update_autocomplete("/session sea")
             self.assertEqual(autolist.option_count, 1)
@@ -525,7 +517,7 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
         repl_mock._get_commands.return_value = {}
 
         app = OllamaAgentApp(repl_mock)
-        async with app.run_test() as pilot:
+        async with app.run_test():
             inp = app.query_one(ReplInput)
             inp.text = "Look at @"
             with patch.object(app, "_file_completions", return_value=[("src/main.py", "1.2 KB")]):
@@ -535,12 +527,16 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
 
     async def test_run_slash_commands_dispatch(self) -> None:
         repl_mock = MagicMock()
-        repl_mock._handle_new_session = AsyncMock()
         repl_mock.console = Console(file=io.StringIO())
         repl_mock.runtime.settings.model.name = "gemma4:26b"
         repl_mock.runtime.settings.model.reasoning_effort = "medium"
         repl_mock._rag_ctx = None
         repl_mock.runtime.yolo_mode = False
+
+        async def _handle_new_session(args: list[str]) -> None:
+            pass
+
+        repl_mock._handle_new_session = _handle_new_session
 
         def _toggle_yolo(args):
             repl_mock.runtime.yolo_mode = not repl_mock.runtime.yolo_mode
@@ -561,6 +557,9 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
             await chat_scroll.mount(UserMessage("clear me"))
             await pilot.pause()
             with patch("ollama_agent.interfaces.repl.new_session", return_value="newsess12345678"):
+                async def _handle_new(args: list[str], _tid: str = "newsess12345678") -> None:
+                    repl_mock.runtime.thread_id = _tid
+                repl_mock._handle_new_session = _handle_new
                 await app._run_slash_command("/clear")
                 await pilot.pause()
                 self.assertEqual(len(list(chat_scroll.query(UserMessage))), 0)
@@ -570,6 +569,9 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
             await chat_scroll.mount(UserMessage("new me"))
             await pilot.pause()
             with patch("ollama_agent.interfaces.repl.new_session", return_value="newsess87654321"):
+                async def _handle_new2(args: list[str], _tid: str = "newsess87654321") -> None:
+                    repl_mock.runtime.thread_id = _tid
+                repl_mock._handle_new_session = _handle_new2
                 await app._run_slash_command("/new")
                 await pilot.pause()
                 self.assertEqual(len(list(chat_scroll.query(UserMessage))), 0)
@@ -588,10 +590,8 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
             # 4. /session resume command (mounting previous conversation)
             human_msg = MagicMock(type="human", content="Past question")
             ai_msg = MagicMock(type="ai", content="Past answer")
-            mock_state = MagicMock()
-            mock_state.values = {"messages": [human_msg, ai_msg]}
-            repl_mock.runtime.graph = MagicMock()
-            repl_mock.runtime.graph.aget_state = AsyncMock(return_value=mock_state)
+            repl_mock.runtime.get_thread_messages = AsyncMock(return_value=[human_msg, ai_msg])
+            repl_mock.runtime.count_effective_tokens = AsyncMock(return_value=42)
 
             with patch("ollama_agent.interfaces.repl.resume_session", return_value="sess12345678"):
                 await app._run_slash_command("/session resume sess12345678")


### PR DESCRIPTION
… test bugs

Production:
- Rewrite compact_context on deepagents public contracts (new agent/compaction.py), removing access to 8 private SummarizationMiddleware internals
- RAG add_directory: embed batches before deleting old points so a failure no longer loses already-indexed content
- Replace global Screen._forward_event monkey-patch with MainScreen subclass installed via App.get_default_screen()
- Use Rich Console public width/height setters; expose AgentRuntime.get_thread_messages() and count_effective_tokens() instead of touching graph/middleware internals from the REPL
- Raise HistoryError on unreadable history DB instead of returning empty results
- Raise MCPConfigError on invalid mcp.json instead of silently loading no tools
- Drop blanket DeprecationWarning suppression; narrow i18n locale detection except clause
- safe_call: document domain-error contract, report HistoryError, stop swallowing SystemExit
- Autocomplete: declare /session switch subcommand

Tests:
- Fix segfault in test_copy_win32 (unmocked ctypes.memmove wrote to mocked int address); full suite now runs 289 tests instead of dying at ~35
- Fix session history DB fixture to match real langgraph schema
- Isolate tests from real Ollama server and system locale leakage via main()
- Fix broken-by-design assertions (params dispatch consoles, approval widget focus pauses, stale Italian translation expectation, compaction chained-cutoff math)

Tooling:
- Add ruff config and dev extra to pyproject.toml