### PR TITLE
fix: resolve 12 bugs found via static analysis

### DIFF
--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -367,10 +367,8 @@ class AgentRuntime:
 
         session_id = new_session_id(values)
         history_path = f"{HISTORY_PATH_PREFIX}/{session_id}.md"
-        summary, file_path = await asyncio.gather(
-            generate_summary(self._model, to_summarize),
-            offload_history(self._backend, to_summarize, history_path),
-        )
+        summary = await generate_summary(self._model, to_summarize)
+        file_path = await offload_history(self._backend, to_summarize, history_path)
 
         new_event: dict[str, Any] = {
             "cutoff_index": compute_state_cutoff(self._summarization_engine, prior_event, cutoff),

--- a/ollama_agent/agent/compaction.py
+++ b/ollama_agent/agent/compaction.py
@@ -138,7 +138,7 @@ async def generate_summary(model: Any, messages: list[Any]) -> str:
     formatted = get_buffer_string(messages, format="xml")
     prompt = DEEPAGENTS_DEFAULT_SUMMARY_PROMPT.format(messages=formatted).rstrip()
     response = await model.ainvoke(prompt)
-    return response.text.strip()
+    return response.content.strip()
 
 
 async def offload_history(backend: Any, messages: list[Any], path: str) -> str:

--- a/ollama_agent/core/common.py
+++ b/ollama_agent/core/common.py
@@ -38,6 +38,8 @@ def extract_text(content: Any, *, sep: str = " ") -> str:
         return sep.join(filter(None, (extract_text(c, sep=sep) for c in content))).strip()
     if isinstance(content, dict):
         text_val = content.get("text") or content.get("content")
+        if text_val is None:
+            return ""
         return extract_text(text_val, sep=sep)
     raise TypeError(f"Unsupported content shape for extract_text: {type(content).__name__}")
 

--- a/ollama_agent/core/prompt_processor.py
+++ b/ollama_agent/core/prompt_processor.py
@@ -204,6 +204,8 @@ def resolve_context_files(
                 add_file(Path(root) / file_name)
             except PromptProcessingError as exc:
                 warnings.append(str(exc))
+                if "limit" in str(exc).lower() or "exceeded" in str(exc).lower():
+                    return ResolvedContext(text_contents, binary_attachments, classifications, list(dict.fromkeys(warnings)))
 
     return ResolvedContext(text_contents, binary_attachments, classifications, list(dict.fromkeys(warnings)))
 
@@ -262,6 +264,7 @@ def process_prompt_mentions(
                 ):
                     break
                 path_str = path_str[:-1]
+                end -= 1
 
         if not path_str:
             continue

--- a/ollama_agent/i18n/locales/ar.json
+++ b/ollama_agent/i18n/locales/ar.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "موضع قائمة الانتظار {pos} خارج النطاق (تحتوي قائمة الانتظار على {count} من العناصر).",
   "Queued ({count})": "في قائمة الانتظار ({count})",
   "more": "المزيد",
-  "tokens": "رموز"
+  "tokens": "رموز",
+  "Usage: /effort [set <level>]": "الاستخدام: /effort [set <المستوى>]",
+  "Usage: /context [set <size>]": "الاستخدام: /context [set <الحجم>]"
 }

--- a/ollama_agent/i18n/locales/de.json
+++ b/ollama_agent/i18n/locales/de.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "Warteschlangenposition {pos} außerhalb des Bereichs (Warteschlange hat {count} Elemente).",
   "Queued ({count})": "In der Warteschlange ({count})",
   "more": "weitere",
-  "tokens": "Tokens"
+  "tokens": "Tokens",
+  "Usage: /effort [set <level>]": "Verwendung: /effort [set <Stufe>]",
+  "Usage: /context [set <size>]": "Verwendung: /context [set <Größe>]"
 }

--- a/ollama_agent/i18n/locales/es.json
+++ b/ollama_agent/i18n/locales/es.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "Posición de cola {pos} fuera de rango (la cola tiene {count} elementos).",
   "Queued ({count})": "En cola ({count})",
   "more": "más",
-  "tokens": "tokens"
+  "tokens": "tokens",
+  "Usage: /effort [set <level>]": "Uso: /effort [set <nivel>]",
+  "Usage: /context [set <size>]": "Uso: /context [set <tamaño>]"
 }

--- a/ollama_agent/i18n/locales/fr.json
+++ b/ollama_agent/i18n/locales/fr.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "Position de file d'attente {pos} hors limites (la file contient {count} éléments).",
   "Queued ({count})": "En file d'attente ({count})",
   "more": "de plus",
-  "tokens": "tokens"
+  "tokens": "tokens",
+  "Usage: /effort [set <level>]": "Utilisation : /effort [set <niveau>]",
+  "Usage: /context [set <size>]": "Utilisation : /context [set <taille>]"
 }

--- a/ollama_agent/i18n/locales/hi.json
+++ b/ollama_agent/i18n/locales/hi.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "कतार स्थिति {pos} सीमा से बाहर है (कतार में {count} आइटम हैं)।",
   "Queued ({count})": "कतारबद्ध ({count})",
   "more": "अधिक",
-  "tokens": "टोकन"
+  "tokens": "टोकन",
+  "Usage: /effort [set <level>]": "उपयोग: /effort [set <level>]",
+  "Usage: /context [set <size>]": "उपयोग: /context [set <size>]"
 }

--- a/ollama_agent/i18n/locales/it.json
+++ b/ollama_agent/i18n/locales/it.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "Posizione della coda {pos} fuori intervallo (la coda contiene {count} elementi).",
   "Queued ({count})": "In coda ({count})",
   "more": "altri",
-  "tokens": "token"
+  "tokens": "token",
+  "Usage: /effort [set <level>]": "Uso: /effort [set <livello>]",
+  "Usage: /context [set <size>]": "Uso: /context [set <dimensione>]"
 }

--- a/ollama_agent/i18n/locales/ja.json
+++ b/ollama_agent/i18n/locales/ja.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "キュー位置 {pos} は範囲外です (キューには {count} 個の項目があります)。",
   "Queued ({count})": "キュー中 ({count})",
   "more": "件",
-  "tokens": "トークン"
+  "tokens": "トークン",
+  "Usage: /effort [set <level>]": "使用法: /effort [set <レベル>]",
+  "Usage: /context [set <size>]": "使用法: /context [set <サイズ>]"
 }

--- a/ollama_agent/i18n/locales/ko.json
+++ b/ollama_agent/i18n/locales/ko.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "대기열 위치 {pos}이(가) 범위를 벗어났습니다(대기열에 {count}개 항목 있음).",
   "Queued ({count})": "대기 중 ({count})",
   "more": "개 더보기",
-  "tokens": "토큰"
+  "tokens": "토큰",
+  "Usage: /effort [set <level>]": "사용법: /effort [set <레벨>]",
+  "Usage: /context [set <size>]": "사용법: /context [set <크기>]"
 }

--- a/ollama_agent/i18n/locales/nl.json
+++ b/ollama_agent/i18n/locales/nl.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "Wachtrijpositie {pos} buiten bereik (wachtrij heeft {count} items).",
   "Queued ({count})": "In wachtrij ({count})",
   "more": "meer",
-  "tokens": "tokens"
+  "tokens": "tokens",
+  "Usage: /effort [set <level>]": "Gebruik: /effort [set <niveau>]",
+  "Usage: /context [set <size>]": "Gebruik: /context [set <grootte>]"
 }

--- a/ollama_agent/i18n/locales/pl.json
+++ b/ollama_agent/i18n/locales/pl.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "Pozycja w kolejce {pos} poza zakresem (kolejka zawiera {count} elementów).",
   "Queued ({count})": "W kolejce ({count})",
   "more": "więcej",
-  "tokens": "tokenów"
+  "tokens": "tokenów",
+  "Usage: /effort [set <level>]": "Użycie: /effort [set <poziom>]",
+  "Usage: /context [set <size>]": "Użycie: /context [set <rozmiar>]"
 }

--- a/ollama_agent/i18n/locales/pt.json
+++ b/ollama_agent/i18n/locales/pt.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "Posição de fila {pos} fora do intervalo (a fila tem {count} itens).",
   "Queued ({count})": "Na fila ({count})",
   "more": "mais",
-  "tokens": "tokens"
+  "tokens": "tokens",
+  "Usage: /effort [set <level>]": "Uso: /effort [set <nível>]",
+  "Usage: /context [set <size>]": "Uso: /context [set <tamanho>]"
 }

--- a/ollama_agent/i18n/locales/ru.json
+++ b/ollama_agent/i18n/locales/ru.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "Позиция в очереди {pos} вне диапазона (в очереди {count} элементов).",
   "Queued ({count})": "В очереди ({count})",
   "more": "еще",
-  "tokens": "токенов"
+  "tokens": "токенов",
+  "Usage: /effort [set <level>]": "Использование: /effort [set <уровень>]",
+  "Usage: /context [set <size>]": "Использование: /context [set <размер>]"
 }

--- a/ollama_agent/i18n/locales/tr.json
+++ b/ollama_agent/i18n/locales/tr.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "Kuyruk konumu {pos} aralık dışında (kuyrukta {count} öğe var).",
   "Queued ({count})": "Kuyrukta ({count})",
   "more": "daha fazla",
-  "tokens": "belirteç"
+  "tokens": "belirteç",
+  "Usage: /effort [set <level>]": "Kullanım: /effort [set <seviye>]",
+  "Usage: /context [set <size>]": "Kullanım: /context [set <boyut>]"
 }

--- a/ollama_agent/i18n/locales/uk.json
+++ b/ollama_agent/i18n/locales/uk.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "Позиція в черзі {pos} поза діапазоном (черга містить {count} елементів).",
   "Queued ({count})": "У черзі ({count})",
   "more": "ще",
-  "tokens": "токенів"
+  "tokens": "токенів",
+  "Usage: /effort [set <level>]": "Використання: /effort [set <рівень>]",
+  "Usage: /context [set <size>]": "Використання: /context [set <розмір>]"
 }

--- a/ollama_agent/i18n/locales/zh.json
+++ b/ollama_agent/i18n/locales/zh.json
@@ -443,5 +443,7 @@
   "Queue position {pos} out of range (queue has {count} items).": "队列位置 {pos} 超出范围（队列有 {count} 项）。",
   "Queued ({count})": "已排队 ({count})",
   "more": "更多",
-  "tokens": "Token"
+  "tokens": "Token",
+  "Usage: /effort [set <level>]": "用法：/effort [set <级别>]",
+  "Usage: /context [set <size>]": "用法：/context [set <大小>]"
 }

--- a/ollama_agent/interfaces/cli.py
+++ b/ollama_agent/interfaces/cli.py
@@ -16,6 +16,7 @@ from ..settings import Settings
 from ..skills import SkillManager, SkillsContext, SkillError
 from ..streaming import run_non_interactive
 from ..tasks.commands import TaskError, TasksContext
+from ..mcp.loader import MCPConfigError
 from .dispatch import build_cli_handlers
 
 
@@ -287,7 +288,7 @@ def handle_cli_commands(
                 result = handlers[handler_key]()
                 if inspect.isawaitable(result):
                     asyncio.run(result)  # type: ignore[arg-type]
-            except (SkillError, TaskError, RAGError, HistoryError) as exc:
+            except (SkillError, TaskError, RAGError, HistoryError, MCPConfigError) as exc:
                 ctx.console.print(f"[red]{exc}[/red]")
                 raise SystemExit(1) from exc
             return True

--- a/ollama_agent/interfaces/dispatch.py
+++ b/ollama_agent/interfaces/dispatch.py
@@ -194,9 +194,12 @@ def build_repl_handlers(
     def handle_model(args: list[str]) -> object:
         if not args or args[0] == "list":
             return list_models(console, current_model(), base_url())
-        if args[0] in ("set", "use", "switch") and len(args) > 1:
-            return switch_model(args[1])
-        if len(args) == 1 and args[0] != "list":
+        if args[0] in ("set", "use", "switch"):
+            if len(args) > 1:
+                return switch_model(args[1])
+            console.print(f"[red]{_('Usage: /model [list | set <model>]')}[/red]")
+            return None
+        if len(args) == 1:
             return switch_model(args[0])
         console.print(f"[red]{_('Usage: /model [list | set <model>]')}[/red]")
         return None
@@ -205,15 +208,23 @@ def build_repl_handlers(
         if not args:
             show_effort(console, get_runtime())
             return None
-        target = args[1] if args[0] in ("set", "use", "switch") and len(args) > 1 else args[0]
-        return switch_effort(target)
+        if args[0] in ("set", "use", "switch"):
+            if len(args) > 1:
+                return switch_effort(args[1])
+            console.print(f"[red]{_('Usage: /effort [set <level>]')}[/red]")
+            return None
+        return switch_effort(args[0])
 
     def handle_context(args: list[str]) -> object:
         if not args:
             show_context_window(console, get_runtime())
             return None
-        target = args[1] if args[0] in ("set", "use", "switch") and len(args) > 1 else args[0]
-        return switch_context_window(target)
+        if args[0] in ("set", "use", "switch"):
+            if len(args) > 1:
+                return switch_context_window(args[1])
+            console.print(f"[red]{_('Usage: /context [set <size>]')}[/red]")
+            return None
+        return switch_context_window(args[0])
 
     def handle_params(args: list[str]) -> object:
         if not args or args[0] == "list":

--- a/ollama_agent/interfaces/tui_components.py
+++ b/ollama_agent/interfaces/tui_components.py
@@ -46,7 +46,7 @@ class AgentHeader(Static):
             else (ms.context_window if isinstance(ms.context_window, int) else 0)
         )
 
-        if isinstance(num_ctx, int) and num_ctx > 0:
+        if isinstance(num_ctx, int) and num_ctx > 0 and isinstance(tokens, (int, float)):
             tokens_val = tokens
             pct = int((tokens_val / num_ctx) * 100)
             if pct > 90:

--- a/ollama_agent/mcp/commands.py
+++ b/ollama_agent/mcp/commands.py
@@ -51,8 +51,8 @@ async def check_mcp_server(
         target = str(conn["url"])
 
     try:
-        client = MultiServerMCPClient({name: conn})  # type: ignore[dict-item,arg-type]
-        tools = await asyncio.wait_for(client.get_tools(), timeout=timeout)
+        async with MultiServerMCPClient({name: conn}) as client:  # type: ignore[dict-item,arg-type]
+            tools = await asyncio.wait_for(client.get_tools(), timeout=timeout)
     except asyncio.TimeoutError:
         return MCPServerStatus(
             name=name,

--- a/ollama_agent/mcp/loader.py
+++ b/ollama_agent/mcp/loader.py
@@ -42,7 +42,7 @@ def _resolve_env(env: dict[str, str], server_name: str) -> dict[str, str]:
             )
         return os.environ[var]
 
-    return {key: _ENV_RE.sub(_replace, value) for key, value in env.items()}
+    return {key: _ENV_RE.sub(_replace, str(value)) for key, value in env.items()}
 
 
 def _build_mcp_connection(server_name: str, cfg: dict[str, Any]) -> dict[str, Any]:

--- a/ollama_agent/rag/manager.py
+++ b/ollama_agent/rag/manager.py
@@ -263,13 +263,12 @@ class RAGManager:
             for i, chunk in enumerate(chunks):
                 flat_chunks_data.append((source, fname, chunk, i, total_chunks))
 
-        # Delete old points for all sources up-front, before batch processing.
         all_sources = {str(fpath) for fpath, _ in all_file_chunks}
-        self._delete_sources_points(client, all_sources)
 
-        # Process in batches.
+        # Process in batches — collect points before committing.
         BATCH_SIZE = 100
         failed_sources: set[str] = set()
+        all_points: list[PointStruct] = []
         for i in range(0, len(flat_chunks_data), BATCH_SIZE):
             batch = flat_chunks_data[i : i + BATCH_SIZE]
             batch_texts = [b[2] for b in batch]
@@ -285,13 +284,12 @@ class RAGManager:
                 failed_sources.update(batch_sources)
                 continue
 
-            points = []
             for (
                 (source, fname, chunk, chunk_idx, total_chunks),
                 embedding,
             ) in zip(batch, embeddings, strict=True):
                 point_id = self._generate_point_id(source, chunk_idx)
-                points.append(
+                all_points.append(
                     PointStruct(
                         id=point_id,
                         vector=embedding,
@@ -304,7 +302,14 @@ class RAGManager:
                         },
                     )
                 )
-            client.upsert(collection_name=self.COLLECTION_NAME, points=points)
+
+        # Only delete and re-insert sources that had ALL batches succeed.
+        successful_sources = all_sources - failed_sources
+        if successful_sources:
+            self._delete_sources_points(client, successful_sources)
+            successful_points = [p for p in all_points if p.payload["source"] in successful_sources]
+            if successful_points:
+                client.upsert(collection_name=self.COLLECTION_NAME, points=successful_points)
 
         # Populate results for successful files
         for fpath, chunks in all_file_chunks:

--- a/ollama_agent/skills/manager.py
+++ b/ollama_agent/skills/manager.py
@@ -88,11 +88,12 @@ class SkillManager(BaseFileStoreManager[SkillInfo]):
         skills: dict[str, SkillInfo] = {}
         if self.builtin_dir is not None and self.builtin_dir.is_dir():
             for d in self.builtin_dir.iterdir():
-                if d.is_dir() and d.name.startswith(prefix):
+                if d.is_dir() and d.name.startswith(prefix) and (d / "SKILL.md").exists():
                     skills[d.name] = _read_skill(d)
-        for d in self.base_dir.iterdir():
-            if d.is_dir() and d.name.startswith(prefix):
-                skills[d.name] = _read_skill(d)
+        if self.base_dir.is_dir():
+            for d in self.base_dir.iterdir():
+                if d.is_dir() and d.name.startswith(prefix) and (d / "SKILL.md").exists():
+                    skills[d.name] = _read_skill(d)
         return skills
 
     def get(self, item_id: str) -> SkillInfo:

--- a/ollama_agent/tasks/manager.py
+++ b/ollama_agent/tasks/manager.py
@@ -61,6 +61,7 @@ class TaskManager(BaseFileStoreManager[Task]):
         path = self._path(task_id)
         if path.exists() and not overwrite:
             raise FileExistsError(_("Task already exists: {task_id}", task_id=task_id))
+        path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = path.with_suffix(".tmp")
         tmp_path.write_text(
             yaml.safe_dump(asdict(task), allow_unicode=True), encoding="utf-8"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -24,10 +24,13 @@ class TestCommonUtilities(unittest.TestCase):
         self.assertEqual(extract_text(payload), "part 1 part 2")
 
     def test_extract_text_unknown_types_raise_type_error(self) -> None:
-        for unknown in (123, None, 4.5, ("a", "b"), {"foo": "bar"}):
+        for unknown in (123, None, 4.5, ("a", "b")):
             with self.subTest(value=unknown):
                 with self.assertRaises(TypeError):
                     extract_text(unknown)
+
+    def test_extract_text_dict_without_text_returns_empty(self) -> None:
+        self.assertEqual(extract_text({"foo": "bar"}), "")
 
     def test_validate_identifier_valid_names(self) -> None:
         self.assertEqual(validate_identifier("valid_name-123"), "valid_name-123")

--- a/tests/test_mcp_loader.py
+++ b/tests/test_mcp_loader.py
@@ -266,6 +266,8 @@ class TestMCPLoader(unittest.IsolatedAsyncioTestCase):
         mock_tool.name = "search_tool"
         mock_client = MagicMock()
         mock_client.get_tools = AsyncMock(return_value=[mock_tool])
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch("ollama_agent.mcp.commands.MultiServerMCPClient", return_value=mock_client):
             status = await check_mcp_server("test-server", cfg)
@@ -280,6 +282,8 @@ class TestMCPLoader(unittest.IsolatedAsyncioTestCase):
         cfg = {"command": "invalid-cmd"}
         mock_client = MagicMock()
         mock_client.get_tools = AsyncMock(side_effect=RuntimeError("Command not found"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch("ollama_agent.mcp.commands.MultiServerMCPClient", return_value=mock_client):
             status = await check_mcp_server("bad-server", cfg)
@@ -347,6 +351,8 @@ class TestMCPLoader(unittest.IsolatedAsyncioTestCase):
             mock_tool.name = "tavily_search"
             mock_client = MagicMock()
             mock_client.get_tools = AsyncMock(return_value=[mock_tool])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
 
             with patch("ollama_agent.mcp.loader.MCP_PATH", tmp_path), \
                  patch("ollama_agent.mcp.commands.MultiServerMCPClient", return_value=mock_client):


### PR DESCRIPTION
Critical:
- compaction: use .content instead of .text on AIMessage (AttributeError crash)
- skills: filter __pycache__ dirs and guard missing base_dir in _collect_skills

High:
- agent: sequential compaction to prevent history duplication on summary failure
- tui: guard against None tokens in header percentage calculation
- rag: defer source deletion until all batches succeed to prevent data corruption
- mcp: close MultiServerMCPClient via async with to prevent zombie processes
- tasks: ensure TASKS_DIR exists before writing task files

Medium:
- dispatch: /model set, /effort set, /context set without arg now show usage
- common: extract_text returns '' for dicts without text/content keys
- prompt_processor: preserve trailing punctuation when replacing @mentions
- mcp loader: coerce env var values to str before regex substitution

Low:
- cli: add MCPConfigError to exception handler

Additional:
- prompt_processor: early return from directory walk on limit exceeded
- i18n: add translations for new usage strings in all 15 locales
- tests: update test_common and test_mcp_loader for new behavior