### PR TITLE
refactor: apply KISS and anti-bloat guidelines across all submodules

### DIFF
--- a/ollama_agent/agent/agent.py
+++ b/ollama_agent/agent/agent.py
@@ -285,8 +285,6 @@ class AgentRuntime:
         async with self._init_lock:
             if self.graph is None:
                 await self.reload()
-            if self.graph is None:
-                raise RuntimeError(_("Agent graph is not initialized"))
         config: dict[str, Any] = {"configurable": {"thread_id": thread}}
         return self.graph, thread, config
 
@@ -369,12 +367,10 @@ class AgentRuntime:
     async def compact_context(self, thread_id: str = "") -> dict[str, Any]:
         """Compact conversation history for the specified thread into a summary."""
         graph, _thread, config = await self._ensure_graph(thread_id)
-        if self._model is None:
-            raise RuntimeError(_("Agent model is not initialized"))
 
         state = await graph.aget_state(config)
-        values: dict[str, Any] = state.values if state and state.values else {}
-        raw_messages = list(values.get("messages") or [])
+        values: dict[str, Any] = state.values
+        raw_messages = list(values.get("messages", []))
         if not raw_messages:
             return {"success": False, "message": _("No messages in session to compact.")}
 
@@ -424,17 +420,17 @@ class AgentRuntime:
         """Return the raw stored messages for a thread (empty when unknown)."""
         graph, _thread, config = await self._ensure_graph(thread_id)
         state = await graph.aget_state(config)
-        values: dict[str, Any] = state.values if state and state.values else {}
-        return list(values.get("messages") or [])
+        values: dict[str, Any] = state.values
+        return list(values.get("messages", []))
 
     async def count_effective_tokens(self, thread_id: str = "") -> int:
         """Count tokens of the effective context for a thread (after compaction)."""
         graph, _thread, config = await self._ensure_graph(thread_id)
         state = await graph.aget_state(config)
-        values: dict[str, Any] = state.values if state and state.values else {}
+        values: dict[str, Any] = state.values
         effective = apply_summarization_event(
             self._summarization_engine,
-            list(values.get("messages") or []),
+            list(values.get("messages", [])),
             values.get(SUMMARIZATION_STATE_KEY),
         )
         return count_tokens_approximately(effective)

--- a/ollama_agent/agent/episodic_memory.py
+++ b/ollama_agent/agent/episodic_memory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import sqlite3
 from collections import defaultdict
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -23,10 +24,10 @@ class HistoryError(RuntimeError):
 
 
 @contextlib.contextmanager
-def connect_history(db_path: Path):
-    """Open the history database as a read-only context manager that closes on exit."""
+def connect_history(db_path: Path, read_only: bool = True) -> Iterator[sqlite3.Connection]:
+    """Open the history database as a context manager that closes on exit."""
     try:
-        conn = sqlite3.connect(f"file:{db_path.resolve()}?mode=ro", uri=True)
+        conn = sqlite3.connect(f"file:{db_path.resolve()}?mode=ro", uri=True) if read_only else sqlite3.connect(str(db_path))
     except sqlite3.Error as e:
         raise HistoryError(_("Failed to open history database {db_path}: {e}", db_path=db_path, e=e)) from e
     try:
@@ -63,8 +64,8 @@ def load_past_user_prompts(db_path: Path = HISTORY_DB_PATH) -> list[str]:
                 if not isinstance(msgs, list):
                     msgs = [msgs]
                 for msg in msgs:
-                    if getattr(msg, "type", "") in ("human", "user"):
-                        text = extract_text(getattr(msg, "content", "")).strip()
+                    if getattr(msg, "type", None) in ("human", "user"):
+                        text = extract_text(msg.content).strip()
                         if text and text not in seen:
                             seen.add(text)
                             prompts.append(text)
@@ -126,6 +127,12 @@ def load_past_conversations(
     return conversations
 
 
+def _format_snippet(role: str, text: str) -> str:
+    truncated = text if len(text) <= 300 else f"{text[:297]}..."
+    role_label = _("User") if role in ("human", "user") else _("Assistant")
+    return f"[{role_label}]: {truncated}"
+
+
 def search_past_conversations_in_db(
     query: str,
     db_path: Path = HISTORY_DB_PATH,
@@ -159,11 +166,11 @@ def search_past_conversations_in_db(
         match_count += sum(formatted_date.lower().count(t) for t in terms)
 
         for msg in msgs:
-            role = getattr(msg, "type", "unknown")
+            role = getattr(msg, "type", None)
             if role not in ("human", "ai", "user", "assistant"):
                 continue
 
-            text = extract_text(getattr(msg, "content", "")).strip()
+            text = extract_text(msg.content).strip()
             if not text:
                 continue
 
@@ -171,23 +178,20 @@ def search_past_conversations_in_db(
             if term_hits > 0:
                 match_count += term_hits
                 if not snippets_full:
-                    truncated = text if len(text) <= 300 else f"{text[:297]}..."
-                    role_label = _("User") if role in ("human", "user") else _("Assistant")
-                    snippets.append(f"[{role_label}]: {truncated}")
-                    total_chars += len(truncated)
+                    snippet = _format_snippet(role, text)
+                    snippets.append(snippet)
+                    total_chars += len(snippet)
                     if total_chars > 1200:
                         snippets_full = True
 
         if match_count > 0:
             if not snippets:
                 for msg in msgs:
-                    role = getattr(msg, "type", "unknown")
+                    role = getattr(msg, "type", None)
                     if role in ("human", "ai", "user", "assistant"):
-                        text = extract_text(getattr(msg, "content", "")).strip()
+                        text = extract_text(msg.content).strip()
                         if text:
-                            truncated = text if len(text) <= 300 else f"{text[:297]}..."
-                            role_label = _("User") if role in ("human", "user") else _("Assistant")
-                            snippets.append(f"[{role_label}]: {truncated}")
+                            snippets.append(_format_snippet(role, text))
                             if len(snippets) >= 2:
                                 break
 

--- a/ollama_agent/agent/middleware.py
+++ b/ollama_agent/agent/middleware.py
@@ -44,7 +44,8 @@ async def _stream_tool_events(request: Any, handler: Any) -> Any:
             _("Tool '{tool_name}' timed out after {timeout_s}s", tool_name=tool_name, timeout_s=timeout_s)
         ) from exc
 
-    content_str = str(getattr(result, "content", result)) if result is not None else ""
+    content = result.content if hasattr(result, "content") else result
+    content_str = str(content)
     out_event: dict[str, Any] = {"type": "tool_output", "output_len": len(content_str)}
     if agent_name:
         out_event["agent_name"] = agent_name

--- a/ollama_agent/agent/subagents.py
+++ b/ollama_agent/agent/subagents.py
@@ -21,10 +21,10 @@ _log = logging.getLogger(__name__)
 
 def list_subagents(
     console: Console,
-    settings: Settings | None = None,
+    settings: Settings,
 ) -> None:
     """List all configured subagents and their properties in a table."""
-    if not settings or not settings.subagents:
+    if not settings.subagents:
         console.print(
             f"[yellow]{_('No subagents configured.')}[/yellow]\n"
             f"[dim]{_('Configure subagents in {path}', path=SETTINGS_PATH)}[/dim]"
@@ -44,24 +44,9 @@ def list_subagents(
     table.add_column(_("MCP Servers"), style="blue")
 
     for sa in settings.subagents:
-        if sa.model:
-            model_str = sa.model
-        elif settings.model.name:
-            model_str = f"[dim]{settings.model.name} ({_('inherited')})[/dim]"
-        else:
-            model_str = f"[dim]{_('inherited')}[/dim]"
-
-        if sa.context_window:
-            ctx_str = str(sa.context_window)
-        elif settings.model.context_window:
-            ctx_str = f"[dim]{settings.model.context_window} ({_('inherited')})[/dim]"
-        else:
-            ctx_str = f"[dim]{_('inherited')}[/dim]"
-
-        if sa.mcp_servers:
-            mcp_str = ", ".join(srv.name for srv in sa.mcp_servers if srv.name)
-        else:
-            mcp_str = "[dim]-[/dim]"
+        model_str = sa.model or f"[dim]{settings.model.name} ({_('inherited')})[/dim]"
+        ctx_str = str(sa.context_window) if sa.context_window else f"[dim]{settings.model.context_window} ({_('inherited')})[/dim]"
+        mcp_str = ", ".join(srv.name for srv in sa.mcp_servers if srv.name) if sa.mcp_servers else "[dim]-[/dim]"
 
         table.add_row(
             sa.name,

--- a/ollama_agent/core/common.py
+++ b/ollama_agent/core/common.py
@@ -43,7 +43,7 @@ def extract_text(content: Any, *, sep: str = " ") -> str:
             return extract_text(content["text"], sep=sep)
         if "content" in content:
             return extract_text(content["content"], sep=sep)
-        return ""
+        raise TypeError("Unsupported dict content for extract_text: missing 'text' or 'content' key")
     raise TypeError(f"Unsupported content shape for extract_text: {type(content).__name__}")
 
 

--- a/ollama_agent/core/models.py
+++ b/ollama_agent/core/models.py
@@ -36,15 +36,13 @@ async def _show_model(model: str, base_url: str) -> Any:
         ) from exc
 
 
-def _parse_modelfile_param(text: str | None, param_name: str) -> str | None:
-    if not text:
-        return None
+def _parse_modelfile_param(text: str, param_name: str) -> str | None:
     pattern = rf"^\s*(?:PARAMETER\s+)?{re.escape(param_name)}\s+([^\s\n]+)"
     match = re.search(pattern, text, re.IGNORECASE | re.MULTILINE)
     return match.group(1).strip("\"'") if match else None
 
 
-def _parse_num_ctx(text: str | None) -> int | None:
+def _parse_num_ctx(text: str) -> int | None:
     val = _parse_modelfile_param(text, "num_ctx")
     return int(val) if val and val.isdigit() else None
 
@@ -107,13 +105,13 @@ async def model_supports_thinking(
     return "thinking" in await get_model_capabilities(model, base_url, show_info=show_info)
 
 
-def _get_model_info(response: Any) -> dict[str, Any]:
+def _get_model_info(response: Any) -> dict[str, Any] | None:
     """Return the model metadata dict from the supported SDK attribute shapes."""
     for attr in ("model_info", "modelinfo"):
         info = getattr(response, attr, None)
         if isinstance(info, dict):
             return info
-    return {}
+    return None
 
 
 async def resolve_context_window(
@@ -143,11 +141,15 @@ async def resolve_context_window(
     response = show_info if show_info is not None else await _show_model(model, base_url)
 
     model_info = _get_model_info(response)
-    if resolved := _model_context_length(model_info):
+    if model_info is not None and (resolved := _model_context_length(model_info)):
         return resolved
 
-    for field_name in ("parameters", "modelfile"):
-        if resolved := _parse_num_ctx(getattr(response, field_name, None)):
+    meta_sources = [
+        getattr(response, "parameters", None),
+        getattr(response, "modelfile", None),
+    ]
+    for text in [t for t in meta_sources if t]:
+        if resolved := _parse_num_ctx(text):
             return resolved
 
     raise ModelContextWindowError(
@@ -236,7 +238,7 @@ async def resolve_model_parameters(
             continue
 
         found_val: Any = None
-        for text in meta_sources:
+        for text in [t for t in meta_sources if t]:
             raw = _parse_modelfile_param(text, param)
             if raw is None and param == "repeat_penalty":
                 raw = _parse_modelfile_param(text, "repetition_penalty")

--- a/ollama_agent/core/prompt_processor.py
+++ b/ollama_agent/core/prompt_processor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import logging
 import mimetypes
 import os
 import re
@@ -13,8 +12,6 @@ from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
 
 from ..i18n import _
-
-_log = logging.getLogger(__name__)
 
 
 class PromptProcessingError(Exception):
@@ -61,7 +58,7 @@ _MIME_EXTENSIONS: dict[str, str] = {
 }
 
 
-def get_file_type(file_path: Path) -> str:
+def get_file_type(file_path: Path) -> str | None:
     """Guess the MIME type of a file, prioritizing explicit text overrides and custom extensions."""
     suffix = file_path.suffix.lower()
     if suffix == ".ts":
@@ -69,7 +66,7 @@ def get_file_type(file_path: Path) -> str:
     if suffix in _MIME_EXTENSIONS:
         return _MIME_EXTENSIONS[suffix]
     mime, _encoding = mimetypes.guess_type(str(file_path))
-    return mime or ""
+    return mime
 
 
 class ResolvedContext(NamedTuple):
@@ -81,8 +78,10 @@ class ResolvedContext(NamedTuple):
     warnings: list[str]
 
 
-def _multimodal_kind(mime: str) -> str | None:
+def _multimodal_kind(mime: str | None) -> str | None:
     """Map a MIME type to a LangChain multimodal type, or None for text."""
+    if not mime:
+        return None
     if mime.startswith("image/"):
         return "image"
     if mime.startswith("video/"):
@@ -105,13 +104,9 @@ def classify_multimodal_file(file_path: Path) -> str | None:
 
 def is_binary_file(file_path: Path) -> bool:
     """Check if a file is binary by searching for null bytes in the first block."""
-    try:
-        with file_path.open("rb") as f:
-            chunk = f.read(1024)
-            return b"\x00" in chunk
-    except OSError as exc:
-        _log.warning("Could not read file %s to check for binary content: %s", file_path, exc)
-        return False
+    with file_path.open("rb") as f:
+        chunk = f.read(1024)
+        return b"\x00" in chunk
 
 
 def _check_file_size(file_path: Path, max_file_size: int) -> int:

--- a/ollama_agent/i18n/__init__.py
+++ b/ollama_agent/i18n/__init__.py
@@ -41,8 +41,8 @@ def _normalize_lang(raw: str) -> str:
 def detect_system_language() -> str:
     """Detect the system language code, falling back to DEFAULT_LOCALE."""
     for var in ("LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG"):
-        val = os.environ.get(var)
-        if val is not None and val.strip():
+        val = os.environ.get(var, "").strip()
+        if val:
             for part in val.split(":"):
                 if part.strip():
                     norm = _normalize_lang(part)
@@ -88,10 +88,7 @@ def set_locale(lang: str | None = None) -> str:
 
 def get_text(message: str, **kwargs: Any) -> str:
     """Translate a message string with optional format arguments."""
-    if _current_locale == DEFAULT_LOCALE:
-        template = message
-    else:
-        template = _translations.get(message, message)
+    template = _translations.get(message, message)
     if kwargs:
         return template.format(**kwargs)
     return template

--- a/ollama_agent/i18n/locales/ar.json
+++ b/ollama_agent/i18n/locales/ar.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "فشل نقل سجل المحادثة إلى {path}: {error}",
   "Malformed summarization event: {detail}": "حدث تلخيص تالف: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "مهلة الأدوات يجب أن تكون أكبر من 0، القيمة المستلمة {timeout_s}",
-  "Agent graph is not initialized": "رسم الوكيل غير مهيأ",
-  "Agent model is not initialized": "نموذج الوكيل غير مهيأ",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "خطأ في إعداد الوكيل الفرعي '{name}': لا يمكن أن يكون system_prompt فارغًا",
   "unknown": "غير معروف",
   "{label} not found: {prefix}": "{label} غير موجود: {prefix}",

--- a/ollama_agent/i18n/locales/de.json
+++ b/ollama_agent/i18n/locales/de.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "Fehler beim Speichern des Konversationsverlaufs nach {path}: {error}",
   "Malformed summarization event: {detail}": "Missgebildetes Zusammenfassungsereignis: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "Das Tool-Timeout muss größer als 0 sein, erhalten {timeout_s}",
-  "Agent graph is not initialized": "Der Agenten-Graph ist nicht initialisiert",
-  "Agent model is not initialized": "Das Agenten-Modell ist nicht initialisiert",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "Konfigurationsfehler des Sub-Agenten '{name}': system_prompt darf nicht leer sein",
   "unknown": "unbekannt",
   "{label} not found: {prefix}": "{label} nicht gefunden: {prefix}",

--- a/ollama_agent/i18n/locales/es.json
+++ b/ollama_agent/i18n/locales/es.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "Error al guardar el historial de conversación en {path}: {error}",
   "Malformed summarization event: {detail}": "Evento de sumarización malformado: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "El tiempo de espera de herramientas debe ser mayor que 0, obtenido {timeout_s}",
-  "Agent graph is not initialized": "El grafo del agente no está inicializado",
-  "Agent model is not initialized": "El modelo del agente no está inicializado",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "Error de configuración del subagente '{name}': system_prompt no puede estar vacío",
   "unknown": "desconocido",
   "{label} not found: {prefix}": "{label} no encontrada: {prefix}",

--- a/ollama_agent/i18n/locales/fr.json
+++ b/ollama_agent/i18n/locales/fr.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "Échec de la sauvegarde de l'historique de conversation vers {path} : {error}",
   "Malformed summarization event: {detail}": "Événement de synthèse malformé : {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "Le délai d'attente des outils doit être supérieur à 0, obtenu {timeout_s}",
-  "Agent graph is not initialized": "Le graphe de l'agent n'est pas initialisé",
-  "Agent model is not initialized": "Le modèle de l'agent n'est pas initialisé",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "Erreur de configuration du sous-agent '{name}' : system_prompt ne peut pas être vide",
   "unknown": "inconnu",
   "{label} not found: {prefix}": "{label} introuvable : {prefix}",

--- a/ollama_agent/i18n/locales/hi.json
+++ b/ollama_agent/i18n/locales/hi.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "बातचीत का इतिहास {path} में सहेजने में विफल: {error}",
   "Malformed summarization event: {detail}": "विकृत सारांश घटना: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "टूल टाइमआउट 0 से अधिक होना चाहिए, प्राप्त {timeout_s}",
-  "Agent graph is not initialized": "एजेंट ग्राफ़ आरंभ नहीं हुआ",
-  "Agent model is not initialized": "एजेंट मॉडल आरंभ नहीं हुआ",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "सब-एजेंट '{name}' कॉन्फ़िगरेशन त्रुटि: system_prompt खाली नहीं हो सकता",
   "unknown": "अज्ञात",
   "{label} not found: {prefix}": "{label} नहीं मिला: {prefix}",

--- a/ollama_agent/i18n/locales/it.json
+++ b/ollama_agent/i18n/locales/it.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "Errore nel salvataggio della cronologia della conversazione su {path}: {error}",
   "Malformed summarization event: {detail}": "Evento di riepilogo malformato: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "Il timeout degli strumenti deve essere maggiore di 0, ottenuto {timeout_s}",
-  "Agent graph is not initialized": "Il grafo dell'agente non è inizializzato",
-  "Agent model is not initialized": "Il modello dell'agente non è inizializzato",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "Errore di configurazione del sottoagente '{name}': system_prompt non può essere vuoto",
   "unknown": "sconosciuto",
   "{label} not found: {prefix}": "{label} non trovata: {prefix}",

--- a/ollama_agent/i18n/locales/ja.json
+++ b/ollama_agent/i18n/locales/ja.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "会話履歴を {path} に退避できませんでした: {error}",
   "Malformed summarization event: {detail}": "不正な要約イベントです: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "ツールのタイムアウトは 0 より大きい必要があります（現在値: {timeout_s}）",
-  "Agent graph is not initialized": "エージェントのグラフが初期化されていません",
-  "Agent model is not initialized": "エージェントのモデルが初期化されていません",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "サブエージェント '{name}' の設定エラー: system_prompt は空にできません",
   "unknown": "不明",
   "{label} not found: {prefix}": "{label}が見つかりません: {prefix}",

--- a/ollama_agent/i18n/locales/ko.json
+++ b/ollama_agent/i18n/locales/ko.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "대화 기록을 {path}에 저장하지 못했습니다: {error}",
   "Malformed summarization event: {detail}": "잘못된 형식의 요약 이벤트: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "도구 시간 초과는 0보다 커야 합니다. 현재 값: {timeout_s}",
-  "Agent graph is not initialized": "에이전트 그래프가 초기화되지 않았습니다",
-  "Agent model is not initialized": "에이전트 모델이 초기화되지 않았습니다",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "서브 에이전트 '{name}' 구성 오류: system_prompt는 비워둘 수 없습니다",
   "unknown": "알 수 없음",
   "{label} not found: {prefix}": "{label} 찾을 수 없음: {prefix}",

--- a/ollama_agent/i18n/locales/nl.json
+++ b/ollama_agent/i18n/locales/nl.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "Kan gespreksgeschiedenis niet naar {path} wegschrijven: {error}",
   "Malformed summarization event: {detail}": "Misvormde samenvattingsgebeurtenis: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "De time-out voor hulpmiddelen moet groter zijn dan 0, ontvangen {timeout_s}",
-  "Agent graph is not initialized": "De agentgraaf is niet geïnitialiseerd",
-  "Agent model is not initialized": "Het agentmodel is niet geïnitialiseerd",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "Configuratiefout van subagent '{name}': system_prompt mag niet leeg zijn",
   "unknown": "onbekend",
   "{label} not found: {prefix}": "{label} niet gevonden: {prefix}",

--- a/ollama_agent/i18n/locales/pl.json
+++ b/ollama_agent/i18n/locales/pl.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "Nie udało się zapisać historii rozmowy w {path}: {error}",
   "Malformed summarization event: {detail}": "Zniekształcone zdarzenie podsumowania: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "Limit czasu narzędzi musi być większy niż 0, otrzymano {timeout_s}",
-  "Agent graph is not initialized": "Graf agenta nie został zainicjalizowany",
-  "Agent model is not initialized": "Model agenta nie został zainicjalizowany",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "Błąd konfiguracji podagentu '{name}': system_prompt nie może być pusty",
   "unknown": "nieznany",
   "{label} not found: {prefix}": "Nie znaleziono: {label}: {prefix}",

--- a/ollama_agent/i18n/locales/pt.json
+++ b/ollama_agent/i18n/locales/pt.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "Falha ao salvar o histórico da conversação em {path}: {error}",
   "Malformed summarization event: {detail}": "Evento de sumarização malformado: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "O tempo limite das ferramentas deve ser maior que 0, obtido {timeout_s}",
-  "Agent graph is not initialized": "O grafo do agente não está inicializado",
-  "Agent model is not initialized": "O modelo do agente não está inicializado",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "Erro de configuração do subagente '{name}': system_prompt não pode estar vazio",
   "unknown": "desconhecido",
   "{label} not found: {prefix}": "{label} não encontrada: {prefix}",

--- a/ollama_agent/i18n/locales/ru.json
+++ b/ollama_agent/i18n/locales/ru.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "Не удалось выгрузить историю беседы в {path}: {error}",
   "Malformed summarization event: {detail}": "Некорректное событие сумаризации: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "Тайм-аут инструментов должен быть больше 0, получено {timeout_s}",
-  "Agent graph is not initialized": "Граф агента не инициализирован",
-  "Agent model is not initialized": "Модель агента не инициализирована",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "Ошибка конфигурации субагента '{name}': system_prompt не может быть пустым",
   "unknown": "неизвестно",
   "{label} not found: {prefix}": "Не найдено: {label}: {prefix}",

--- a/ollama_agent/i18n/locales/tr.json
+++ b/ollama_agent/i18n/locales/tr.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "Konuşma geçmişi {path} üzerine kaydedilemedi: {error}",
   "Malformed summarization event: {detail}": "Bozuk özetleme olayı: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "Araç zaman aşımı 0'dan büyük olmalı, alınan {timeout_s}",
-  "Agent graph is not initialized": "Ajan grafiği başlatılmadı",
-  "Agent model is not initialized": "Ajan modeli başlatılmadı",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "Alt ajan '{name}' yapılandırma hatası: system_prompt boş olamaz",
   "unknown": "bilinmiyor",
   "{label} not found: {prefix}": "{label} bulunamadı: {prefix}",

--- a/ollama_agent/i18n/locales/uk.json
+++ b/ollama_agent/i18n/locales/uk.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "Не вдалося вивантажити історію розмови до {path}: {error}",
   "Malformed summarization event: {detail}": "Пошкоджена подія сумаризації: {detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "Тайм-аут інструментів має бути більшим за 0, отримано {timeout_s}",
-  "Agent graph is not initialized": "Граф агента не ініціалізовано",
-  "Agent model is not initialized": "Модель агента не ініціалізовано",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "Помилка конфігурації субагента '{name}': system_prompt не може бути порожнім",
   "unknown": "невідомо",
   "{label} not found: {prefix}": "{label} не знайдено: {prefix}",

--- a/ollama_agent/i18n/locales/zh.json
+++ b/ollama_agent/i18n/locales/zh.json
@@ -367,8 +367,6 @@
   "Failed to offload conversation history to {path}: {error}": "会话历史转存到 {path} 失败：{error}",
   "Malformed summarization event: {detail}": "格式错误的摘要事件：{detail}",
   "Tool timeout must be greater than 0, got {timeout_s}": "工具超时时间必须大于 0，当前为 {timeout_s}",
-  "Agent graph is not initialized": "智能体图未初始化",
-  "Agent model is not initialized": "智能体模型未初始化",
   "Subagent '{name}' configuration error: system_prompt cannot be empty": "子智能体 '{name}' 配置错误：system_prompt 不能为空",
   "unknown": "未知",
   "{label} not found: {prefix}": "{label} 未找到: {prefix}",

--- a/ollama_agent/interfaces/dispatch.py
+++ b/ollama_agent/interfaces/dispatch.py
@@ -11,6 +11,7 @@ from rich.console import Console
 
 from ..agent import AgentRuntime, list_subagents
 from ..agent.episodic_memory import HistoryError
+from ..core import DEFAULT_REASONING_EFFORT
 from ..i18n import _
 from ..mcp import list_mcp_servers, reload_mcp_servers
 from ..mcp.loader import MCPConfigError
@@ -114,7 +115,7 @@ def build_cli_handlers(
             title=args.title,
             prompt=args.task_prompt,
             model=(args.task_model or args.model or ""),
-            reasoning_effort=(args.task_effort or args.effort),
+            reasoning_effort=(args.task_effort or args.effort or DEFAULT_REASONING_EFFORT),
             force=args.force,
         ),
         ("rag", "list"): lambda: list_rag_databases(rag_ctx),

--- a/ollama_agent/interfaces/model_commands.py
+++ b/ollama_agent/interfaces/model_commands.py
@@ -340,7 +340,7 @@ def ensure_model_configured(
             save_settings(settings)
             return settings.model.name
 
-    out = console if console is not None else Console()
+    out = console or Console()
     if configured:
         not_avail_msg = _("Configured model '{configured}' is not available in Ollama.", configured=configured)
         out.print(f"[yellow]{not_avail_msg}[/yellow]")

--- a/ollama_agent/interfaces/repl.py
+++ b/ollama_agent/interfaces/repl.py
@@ -874,7 +874,7 @@ class OllamaAgentApp(App):
                     self.show_system_notice(f"[bold #f87171]✕ {_('Usage: /task run <id> [-y]')}[/bold #f87171]")
                     return
                 try:
-                    tid, t = self.repl._task_ctx._find_or_exit(target_id)
+                    tid, t = self.repl._task_ctx._resolve_task(target_id)
                 except TaskError as exc:
                     self.show_system_notice(f"[red]{exc}[/red]")
                     return
@@ -946,12 +946,9 @@ class OllamaAgentApp(App):
                 if self._prompt_queue:
                     self._prompt_queue.clear()
                     self._update_queue_ui()
-                inp = self.query_one(ReplInput)
-                inp.disabled = False
-                inp.focus()
-                footer.set_approval(False)
-                self._is_approval_pending = False
                 raise
+            inp = self.query_one(ReplInput)
+            inp.disabled = False
 
             # Check if the execution got interrupted
             config = {"configurable": {"thread_id": self.repl.runtime.thread_id}}
@@ -959,8 +956,6 @@ class OllamaAgentApp(App):
             if state.interrupts:
                 action_requests = extract_action_requests({"interrupts": state.interrupts})
                 self._is_approval_pending = True
-                inp = self.query_one(ReplInput)
-                inp.disabled = False
                 footer.set_approval(True)
                 approval_widget = ToolApprovalWidget(
                     action_requests=action_requests,
@@ -971,8 +966,6 @@ class OllamaAgentApp(App):
                 agent_msg.mount(approval_widget)
                 self._deferred_scroll()
             else:
-                inp = self.query_one(ReplInput)
-                inp.disabled = False
                 inp.focus()
         finally:
             self._is_generating = False

--- a/ollama_agent/interfaces/session_commands.py
+++ b/ollama_agent/interfaces/session_commands.py
@@ -32,7 +32,7 @@ _serializer = JsonPlusSerializer()
 
 def is_current(thread_id: str, current_thread_id: str) -> bool:
     """Return whether *thread_id* is the current session (exact match or bidirectional prefix match)."""
-    if not thread_id or not current_thread_id:
+    if not thread_id.strip() or not current_thread_id.strip():
         return False
     return (
         thread_id == current_thread_id
@@ -176,18 +176,15 @@ def delete_session(
         return False
 
     try:
-        conn = sqlite3.connect(str(db_path))
-        try:
+        with connect_history(db_path, read_only=False) as conn:
             cursor = conn.cursor()
             cursor.execute("DELETE FROM checkpoints WHERE thread_id = ?", (resolved,))
             cursor.execute("DELETE FROM writes WHERE thread_id = ?", (resolved,))
             conn.commit()
-        finally:
-            conn.close()
         deleted_msg = _("Deleted session: {resolved}", resolved=resolved)
         console.print(f"[green]✓ {deleted_msg}[/green]")
         return True
-    except (sqlite3.Error, OSError) as exc:
+    except (sqlite3.Error, OSError, HistoryError) as exc:
         failed_msg = _("Failed to delete session '{resolved}': {exc}", resolved=resolved, exc=exc)
         console.print(f"[red]{failed_msg}[/red]")
         return False
@@ -226,39 +223,24 @@ async def export_session(
 
     for msg in messages:
         role = getattr(msg, "type", "unknown")
-        raw_content = getattr(msg, "content", "")
-        content = extract_text(raw_content)
+        content = extract_text(getattr(msg, "content", ""))
 
         if role in ("human", "user"):
-            lines.append(f"## 👤 {user_label}")
-            lines.append("")
-            lines.append(content)
-            lines.append("")
+            lines.extend([f"## 👤 {user_label}", "", content, ""])
         elif role in ("ai", "assistant"):
-            lines.append(f"## 🤖 {asst_label}")
-            lines.append("")
+            lines.extend([f"## 🤖 {asst_label}", ""])
             if content:
-                lines.append(content)
-                lines.append("")
-            tool_calls = getattr(msg, "tool_calls", None)
-            if tool_calls and isinstance(tool_calls, list):
-                for tc in tool_calls:
-                    tc_name = tc.get("name", "tool") if isinstance(tc, dict) else getattr(tc, "name", "tool")
-                    tc_args = tc.get("args", {}) if isinstance(tc, dict) else getattr(tc, "args", {})
-                    tool_call_hdr = _("Tool: {name}", name=tc_name)
-                    lines.append(f"### ⚙ {tool_call_hdr}")
-                    lines.append("```json")
-                    lines.append(json.dumps(tc_args, indent=2, ensure_ascii=False) if isinstance(tc_args, dict) else str(tc_args))
-                    lines.append("```")
-                    lines.append("")
-        elif role in ("tool",):
+                lines.extend([content, ""])
+            for tc in getattr(msg, "tool_calls", None) or []:
+                tc_name = tc.get("name", "tool") if isinstance(tc, dict) else getattr(tc, "name", "tool")
+                tc_args = tc.get("args", {}) if isinstance(tc, dict) else getattr(tc, "args", {})
+                tool_call_hdr = _("Tool: {name}", name=tc_name)
+                args_str = json.dumps(tc_args, indent=2, ensure_ascii=False) if isinstance(tc_args, dict) else str(tc_args)
+                lines.extend([f"### ⚙ {tool_call_hdr}", "```json", args_str, "```", ""])
+        elif role == "tool":
             name = getattr(msg, "name", "tool")
             tool_hdr = _("Tool: {name}", name=name)
-            lines.append(f"### ⚙ {tool_hdr}")
-            lines.append("```")
-            lines.append(content)
-            lines.append("```")
-            lines.append("")
+            lines.extend([f"### ⚙ {tool_hdr}", "```", content, "```", ""])
 
     target_file = Path(output_path).expanduser().resolve() if output_path else Path.cwd() / f"session_{resolved[:8]}.md"
     target_file.parent.mkdir(parents=True, exist_ok=True)

--- a/ollama_agent/interfaces/tui_components.py
+++ b/ollama_agent/interfaces/tui_components.py
@@ -41,7 +41,7 @@ class AgentHeader(Static):
     def update_header(self) -> None:
         ms = self.repl.runtime.settings.model
         tokens = self.repl.runtime.last_context_tokens
-        eff_ctx = getattr(self.repl.runtime, "effective_context_window", None)
+        eff_ctx = self.repl.runtime.effective_context_window
         num_ctx = eff_ctx if isinstance(eff_ctx, int) and eff_ctx > 0 else (ms.context_window if isinstance(ms.context_window, int) else 0)
 
         if num_ctx > 0 and isinstance(tokens, (int, float)):
@@ -186,8 +186,8 @@ class SystemOutputWidget(Static):
 
     def show_output(self, content: str | Text, title: str | None = None) -> None:
         self.display = True
-        display_title = title if title is not None else _("System Output")
-        header = f"[bold #38bdf8]⚙ {escape(display_title) if isinstance(display_title, str) else display_title}[/bold #38bdf8]  [dim]({_('esc to dismiss')})[/dim]"
+        display_title = title or _("System Output")
+        header = f"[bold #38bdf8]⚙ {escape(display_title)}[/bold #38bdf8]  [dim]({_('esc to dismiss')})[/dim]"
         if isinstance(content, Text):
             header_text = Text.from_markup(header + "\n")
             self.update(Text.assemble(header_text, content))
@@ -651,16 +651,13 @@ class ToolApprovalWidget(Container):
         self.buttons_container.remove()
         self.buttons_container = None
 
-        status_text = ""
-        if decision_type == "approve-btn":
-            status_text = f"[bold #34d399]✓ {_('Approved')}[/bold #34d399]"
-        elif decision_type == "reject-btn":
-            status_text = f"[bold #f87171]✗ {_('Rejected')}[/bold #f87171]"
-        elif decision_type == "allow-btn":
-            status_text = f"[bold #38bdf8]✓ {_('Allowed for session & approved')}[/bold #38bdf8]"
-        elif decision_type == "cancel-btn":
-            status_text = f"[bold #f87171]✗ {_('Cancelled')}[/bold #f87171]"
-
+        status_map = {
+            "approve-btn": f"[bold #34d399]✓ {_('Approved')}[/bold #34d399]",
+            "reject-btn": f"[bold #f87171]✗ {_('Rejected')}[/bold #f87171]",
+            "allow-btn": f"[bold #38bdf8]✓ {_('Allowed for session & approved')}[/bold #38bdf8]",
+            "cancel-btn": f"[bold #f87171]✗ {_('Cancelled')}[/bold #f87171]",
+        }
+        status_text = status_map.get(decision_type or "", "")
         self.mount(Static(f"  {status_text}", classes="approval-status"))
 
         inp = self.app_ref.query_one(ReplInput)

--- a/ollama_agent/main.py
+++ b/ollama_agent/main.py
@@ -25,17 +25,16 @@ warnings.filterwarnings(
 
 def main() -> None:
     """Main entry point."""
-    set_locale()
-
     parser = create_argument_parser()
     args = parser.parse_args()
 
-    if args.command and args.prompt:
-        parser.error(_("--prompt cannot be used together with a subcommand."))
-
-    # Apply language overrides first (before config-reset so messages use chosen locale)
     if args.language:
         set_locale(args.language)
+    else:
+        set_locale()
+
+    if args.command and args.prompt:
+        parser.error(_("--prompt cannot be used together with a subcommand."))
 
     if args.config_reset:
         console = Console()
@@ -48,7 +47,7 @@ def main() -> None:
 
     if args.language:
         settings.runtime.language = args.language
-    if settings.runtime.language:
+    elif settings.runtime.language:
         set_locale(settings.runtime.language)
 
     # Apply CLI overrides

--- a/ollama_agent/mcp/commands.py
+++ b/ollama_agent/mcp/commands.py
@@ -44,17 +44,17 @@ async def check_mcp_server(
     except MCPConfigError as exc:
         return MCPServerStatus(name=name, transport="", target="", status="failed", tools=[], error=str(exc))
 
-    transport = str(conn["transport"])
+    transport = conn["transport"]
     if "command" in conn:
         target = f"{conn['command']} {' '.join(conn['args'])}".strip()
     else:
-        target = str(conn["url"])
+        target = conn["url"]
 
     try:
         async with asyncio.timeout(timeout):
             async with MultiServerMCPClient({name: conn}) as client:  # type: ignore[dict-item,arg-type]
                 tools = await client.get_tools()
-    except (TimeoutError, asyncio.TimeoutError):
+    except TimeoutError:
         return MCPServerStatus(
             name=name,
             transport=transport,

--- a/ollama_agent/mcp/loader.py
+++ b/ollama_agent/mcp/loader.py
@@ -53,7 +53,7 @@ def _build_mcp_connection(server_name: str, cfg: dict[str, Any]) -> dict[str, An
     """
     transport = cfg.get("transport") or cfg.get("type")
 
-    if cfg.get("command"):
+    if "command" in cfg:
         args = cfg.get("args", [])
         if not isinstance(args, list):
             raise MCPConfigError(
@@ -77,8 +77,7 @@ def _build_mcp_connection(server_name: str, cfg: dict[str, Any]) -> dict[str, An
                 out["env"] = resolved
         return out
 
-    url = cfg.get("url") or cfg.get("httpUrl")
-    if url:
+    if "url" in cfg:
         if transport is not None and transport not in _KNOWN_TRANSPORTS:
             raise MCPConfigError(
                 _(
@@ -87,7 +86,7 @@ def _build_mcp_connection(server_name: str, cfg: dict[str, Any]) -> dict[str, An
                     transport=transport,
                 )
             )
-        out = {"transport": transport if transport is not None else "http", "url": url}
+        out = {"transport": transport if transport is not None else "http", "url": cfg["url"]}
         for k in ("headers", "timeout", "sse_read_timeout", "session_kwargs"):
             if k in cfg:
                 out[k] = cfg[k]
@@ -152,22 +151,8 @@ async def _connect_and_load(name: str, conn: dict[str, Any]) -> list[Any]:
     return tools
 
 
-async def load_main_mcp_tools() -> list[Any]:
-    """Load flat MCP tools for the main agent from mcp.json.
-
-    Raises MCPConfigError when the config is unreadable, malformed, or any
-    server fails to connect.
-    """
-    servers_cfg = await _read_main_config()
-
-    connections: dict[str, dict[str, Any]] = {}
-    for name, cfg in servers_cfg.items():
-        if not isinstance(cfg, dict):
-            raise MCPConfigError(
-                _("MCP server '{name}': configuration must be an object", name=name)
-            )
-        connections[name] = _build_mcp_connection(name, cfg)
-
+async def _load_tools_from_connections(connections: dict[str, dict[str, Any]]) -> list[Any]:
+    """Connect to multiple MCP servers concurrently and return all discovered tools."""
     if not connections:
         return []
 
@@ -185,6 +170,25 @@ async def load_main_mcp_tools() -> list[Any]:
     return [tool for t in tasks for tool in t.result()]
 
 
+async def load_main_mcp_tools() -> list[Any]:
+    """Load flat MCP tools for the main agent from mcp.json.
+
+    Raises MCPConfigError when the config is unreadable, malformed, or any
+    server fails to connect.
+    """
+    servers_cfg = await _read_main_config()
+
+    connections: dict[str, dict[str, Any]] = {}
+    for name, cfg in servers_cfg.items():
+        if not isinstance(cfg, dict):
+            raise MCPConfigError(
+                _("MCP server '{name}': configuration must be an object", name=name)
+            )
+        connections[name] = _build_mcp_connection(name, cfg)
+
+    return await _load_tools_from_connections(connections)
+
+
 async def load_subagent_mcp_tools(
     subagent_name: str,
     mcp_servers: list[SubAgentMCPServer],
@@ -199,7 +203,7 @@ async def load_subagent_mcp_tools(
     seen_names: set[str] = set()
     connections: dict[str, dict[str, Any]] = {}
     for srv in mcp_servers:
-        name = srv.name.strip() if srv.name else ""
+        name = srv.name.strip()
         if not name:
             raise MCPConfigError(
                 _("Subagent '{subagent_name}': MCP server name cannot be empty", subagent_name=subagent_name)
@@ -211,17 +215,6 @@ async def load_subagent_mcp_tools(
         seen_names.add(name)
         connections[name] = _build_mcp_connection(name, {"command": srv.command, "args": srv.args, "env": srv.env})
 
-    tasks: list[asyncio.Task[list[Any]]] = []
-    try:
-        async with asyncio.TaskGroup() as tg:
-            for name, conn in connections.items():
-                tasks.append(tg.create_task(_connect_and_load(name, conn)))
-    except ExceptionGroup as eg:
-        for exc in eg.exceptions:
-            if isinstance(exc, MCPConfigError):
-                raise exc from eg
-        raise
-
-    tools = [tool for t in tasks for tool in t.result()]
+    tools = await _load_tools_from_connections(connections)
     _log.info("Subagent '%s': loaded %d MCP tools", subagent_name, len(tools))
     return tools

--- a/ollama_agent/rag/commands.py
+++ b/ollama_agent/rag/commands.py
@@ -26,7 +26,7 @@ class RAGContext:
     rag_manager: RAGManager
     console: Console = field(default_factory=Console)
 
-    def _find_or_exit(self, name: str) -> str:
+    def resolve_database(self, name: str) -> str:
         """Find a database by name/prefix or raise RAGError."""
         target = name.strip()
         if not target:
@@ -79,7 +79,7 @@ def create_rag_database(ctx: RAGContext, name: str) -> None:
 
 def delete_rag_database(ctx: RAGContext, name: str) -> None:
     """Delete a RAG database."""
-    full_name = ctx._find_or_exit(name)
+    full_name = ctx.resolve_database(name)
     ctx.rag_manager.delete_database(full_name)
     ctx.console.print(
         f"[green]✓ {_('Deleted RAG database: {full_name}', full_name=full_name)}[/green]"
@@ -88,7 +88,7 @@ def delete_rag_database(ctx: RAGContext, name: str) -> None:
 
 def load_rag_database(ctx: RAGContext, name: str) -> None:
     """Load a RAG database."""
-    full_name = ctx._find_or_exit(name)
+    full_name = ctx.resolve_database(name)
     ctx.rag_manager.load_database(full_name)
     ctx.console.print(
         f"[green]✓ {_('Loaded RAG database: {full_name}', full_name=full_name)}[/green]"

--- a/ollama_agent/rag/manager.py
+++ b/ollama_agent/rag/manager.py
@@ -88,7 +88,7 @@ class RAGManager:
                 continue
             is_active = path.name == self._current_db
             chunks = None
-            if is_active and self._client is not None:
+            if is_active:
                 try:
                     info = self._client.get_collection(self.COLLECTION_NAME)
                     chunks = info.points_count
@@ -114,9 +114,8 @@ class RAGManager:
 
         db_path.mkdir(parents=True, exist_ok=True)
 
-        client: QdrantClient | None = None
+        client = QdrantClient(path=str(db_path))
         try:
-            client = QdrantClient(path=str(db_path))
             client.create_collection(
                 collection_name=self.COLLECTION_NAME,
                 vectors_config=VectorParams(
@@ -125,14 +124,10 @@ class RAGManager:
                 ),
             )
         except Exception as e:
-            if client is not None:
-                client.close()
-                client = None
-            shutil.rmtree(db_path, ignore_errors=True)
+            shutil.rmtree(db_path)
             raise RAGError(_("Failed to create database '{name}': {e}", name=name, e=e)) from e
         finally:
-            if client is not None:
-                client.close()
+            client.close()
 
         logger.info("Created RAG database: %s", name)
         return name
@@ -161,9 +156,7 @@ class RAGManager:
         if not db_path.exists():
             raise RAGError(_("Database '{name}' not found", name=name))
 
-        # Unload current database if any
-        if self._client is not None:
-            self._client.close()
+        self.unload()
 
         try:
             self._client = QdrantClient(path=str(db_path))
@@ -255,20 +248,22 @@ class RAGManager:
             if not file_path.is_file():
                 continue
 
-            if extensions and file_path.suffix.lower() not in extensions:
+            if file_path.suffix.lower() not in extensions:
                 results["skipped"] += 1
                 continue
 
             try:
                 content = self._read_file(file_path, allowed_extensions=extensions)
-                if not content.strip():
-                    raise RAGError(_("File is empty: {file_path}", file_path=file_path))
-
-                chunks = self._chunk_text(content)
-                all_file_chunks.append((file_path, chunks))
             except Exception as e:
-                logger.warning("Failed to process %s: %s", file_path, e)
+                logger.warning("Failed to read %s: %s", file_path, e)
                 results["failed"] += 1
+                continue
+
+            if not content.strip():
+                continue
+
+            chunks = self._chunk_text(content)
+            all_file_chunks.append((file_path, chunks))
 
         for file_path, chunks in all_file_chunks:
             source = str(file_path)
@@ -387,14 +382,8 @@ class RAGManager:
 
     def _delete_source_points(self, client: QdrantClient, source: str) -> None:
         """Delete all points previously indexed for a given source path."""
-        self._delete_sources_points(client, {source})
-
-    def _delete_sources_points(self, client: QdrantClient, sources: set[str]) -> None:
-        """Delete all points previously indexed for the given source paths."""
-        if not sources:
-            return
         filt = Filter(
-            must=[FieldCondition(key="source", match=MatchAny(any=sorted(sources)))]
+            must=[FieldCondition(key="source", match=MatchAny(any=[source]))]
         )
         try:
             client.delete(
@@ -402,7 +391,7 @@ class RAGManager:
             )
         except Exception as e:
             raise RAGError(
-                _("Failed to delete existing points for source '{source}': {e}", source=", ".join(sorted(sources)), e=e)
+                _("Failed to delete existing points for source '{source}': {e}", source=source, e=e)
             ) from e
 
     def _chunk_text(self, text: str) -> list[str]:

--- a/ollama_agent/settings/config.py
+++ b/ollama_agent/settings/config.py
@@ -188,7 +188,7 @@ class Settings:
 # ---------------------------------------------------------------------------
 
 
-def _dataclass_from_dict(cls: type[Any], raw: Any) -> Any:
+def _dataclass_from_dict[T](cls: type[T], raw: Any) -> T:
     if raw is None:
         return cls()
     if not isinstance(raw, dict):
@@ -218,17 +218,17 @@ def _subagents_from_list(
             raise ValueError(
                 _("Expected mapping for subagent, got {type_name}", type_name=type(item).__name__)
             )
-        mcp_servers_raw = item.get("mcp_servers")
-        if mcp_servers_raw is not None and not isinstance(mcp_servers_raw, list):
-            raise ValueError(
-                _("Expected list for mcp_servers, got {type_name}", type_name=type(mcp_servers_raw).__name__)
-            )
-        mcp_servers = [
-            _dataclass_from_dict(SubAgentMCPServer, m)
-            for m in (mcp_servers_raw or [])
-        ]
-        data = {k: v for k, v in item.items() if k != "mcp_servers"}
-        data["mcp_servers"] = mcp_servers
+        data = dict(item)
+        if "mcp_servers" in item:
+            mcp_servers_raw = item["mcp_servers"]
+            if not isinstance(mcp_servers_raw, list):
+                raise ValueError(
+                    _("Expected list for mcp_servers, got {type_name}", type_name=type(mcp_servers_raw).__name__)
+                )
+            data["mcp_servers"] = [
+                _dataclass_from_dict(SubAgentMCPServer, m)
+                for m in mcp_servers_raw
+            ]
         subagents.append(_dataclass_from_dict(SubAgentSettings, data))
     return subagents
 
@@ -340,9 +340,9 @@ def ensure_memory_file(memory_path: Path = MEMORY_PATH) -> Path:
     return memory_path
 
 
-def find_agents_file(start_dir: Path | None = None) -> Path | None:
+def find_agents_file(start_dir: Path = Path(".")) -> Path | None:
     """Find AGENTS.md in the given directory or its parent hierarchy up to git root."""
-    current = (start_dir or Path.cwd()).resolve()
+    current = start_dir.resolve()
     for parent in [current, *current.parents]:
         for candidate in ("AGENTS.md", "agents.md", ".agents.md"):
             target = parent / candidate

--- a/ollama_agent/skills/commands.py
+++ b/ollama_agent/skills/commands.py
@@ -42,10 +42,6 @@ class SkillsContext:
             matches = self.skill_manager.find_matches(skill_id)
         except ValueError as exc:
             raise ValidationError(str(exc)) from exc
-        except (FileNotFoundError, OSError) as exc:
-            raise SkillNotFoundError(
-                _("{label} not found: {prefix}", label=_("Skill"), prefix=skill_id)
-            ) from exc
         return resolve_unique_match(
             matches,
             skill_id,
@@ -114,7 +110,7 @@ def delete_skill(ctx: SkillsContext, skill_id: str) -> None:
     sid, info = ctx._resolve_skill(skill_id)
     try:
         ctx.skill_manager.delete(sid)
-    except (FileNotFoundError, OSError) as exc:
+    except FileNotFoundError as exc:
         raise SkillNotFoundError(str(exc)) from exc
     except ValueError as exc:
         raise SkillError(str(exc)) from exc

--- a/ollama_agent/skills/manager.py
+++ b/ollama_agent/skills/manager.py
@@ -30,16 +30,13 @@ class SkillInfo:
 
 
 def _find_skill_file(skill_dir: Path) -> Path | None:
-    """Find SKILL.md (case-insensitive) inside skill_dir."""
+    """Find SKILL.md (or skill.md) inside skill_dir."""
     if not skill_dir.is_dir():
         return None
     if (skill_dir / "SKILL.md").is_file():
         return skill_dir / "SKILL.md"
     if (skill_dir / "skill.md").is_file():
         return skill_dir / "skill.md"
-    for item in skill_dir.iterdir():
-        if item.is_file() and item.name.lower() == "skill.md":
-            return item
     return None
 
 
@@ -56,7 +53,7 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
         raise ValueError(_("Unclosed YAML frontmatter"))
     yaml_str = stripped[first_line_end + 1 : match.start()]
     try:
-        meta = yaml.safe_load(yaml_str) or {}
+        meta = yaml.safe_load(yaml_str)
     except yaml.YAMLError as exc:
         raise ValueError(_("Invalid YAML frontmatter: {exc}", exc=exc)) from exc
     if not isinstance(meta, dict):
@@ -73,13 +70,11 @@ def _read_skill(skill_dir: Path) -> SkillInfo:
         raise ValueError(_("SKILL.md exceeds 10 MB: {path}", path=skill_file))
     raw = skill_file.read_text(encoding="utf-8")
     meta, _body = _parse_frontmatter(raw)
-    name = meta.get("name")
-    description = meta.get("description")
-    if not name or not description:
+    if "name" not in meta or "description" not in meta or not meta["name"] or not meta["description"]:
         raise ValueError(
             _("Skill frontmatter must define non-empty 'name' and 'description': {path}", path=skill_file)
         )
-    return SkillInfo(name=str(name), description=str(description), content=raw)
+    return SkillInfo(name=str(meta["name"]), description=str(meta["description"]), content=raw)
 
 
 class SkillManager(BaseFileStoreManager[SkillInfo]):
@@ -126,10 +121,6 @@ class SkillManager(BaseFileStoreManager[SkillInfo]):
     def find_matches(self, prefix: str) -> list[tuple[str, SkillInfo]]:
         """Return all skills whose id starts with *prefix*."""
         prefix = self.validate_skill_id(prefix)
-        try:
-            return [(prefix, self.get(prefix))]
-        except FileNotFoundError:
-            pass
         return sorted(self._collect_skills(prefix).items(), key=lambda x: x[1].name.lower())
 
     def list_all(self) -> list[tuple[str, SkillInfo]]:

--- a/ollama_agent/streaming/base.py
+++ b/ollama_agent/streaming/base.py
@@ -18,9 +18,6 @@ class StreamingRenderer(ABC):
     def on_event(self, event: dict[str, Any]) -> None:
         """Dispatch event to type-specific handler (on_<type>)."""
         etype = event["type"]
-        if etype == "event":
-            _log.debug("Skipping event with unroutable type: %s", etype)
-            return
         handler = getattr(self, f"on_{etype}", None)
         if not callable(handler) or handler == self.on_event:
             _log.debug("Unhandled event type skipped: %s", etype)

--- a/ollama_agent/streaming/console_renderer.py
+++ b/ollama_agent/streaming/console_renderer.py
@@ -122,7 +122,7 @@ class ConsoleStreamingRenderer(StreamingRenderer):
             self.console.print(f"  {_('Tool:')} [bold]{name}[/bold]")
             self.console.print(f"  {_('Arguments:')} {args}")
 
-        if sys.stdin is None or not sys.stdin.isatty():
+        if not sys.stdin.isatty():
             hint = _(
                 "Cannot request tool approval in a non-interactive session. Re-run with -y (--yolo) to auto-approve sensitive tools."
             )

--- a/ollama_agent/streaming/events.py
+++ b/ollama_agent/streaming/events.py
@@ -42,13 +42,12 @@ async def stream_agent_events(
                 etype = event["type"]
                 if etype in ignored:
                     continue
+                if etype == "interrupt":
+                    interrupt_event = event
+                    continue
                 if etype == "error":
                     completed = False
-                    renderer.on_event(event)
-                elif etype == "interrupt":
-                    interrupt_event = event
-                else:
-                    renderer.on_event(event)
+                renderer.on_event(event)
 
             if interrupt_event is not None:
                 decisions = await renderer.handle_interrupt(interrupt_event, runtime)

--- a/ollama_agent/streaming/parsers.py
+++ b/ollama_agent/streaming/parsers.py
@@ -16,12 +16,12 @@ def streaming_text(content: Any) -> str:
     if isinstance(content, str):
         return content
     if isinstance(content, dict):
-        return content["text"] if content.get("type") == "text" and "text" in content else ""
+        return content["text"] if content.get("type") == "text" else ""
     if isinstance(content, list):
         return "".join(
             b["text"]
             for b in content
-            if isinstance(b, dict) and b.get("type") == "text" and "text" in b
+            if isinstance(b, dict) and b.get("type") == "text"
         )
     return ""
 
@@ -32,7 +32,7 @@ def streaming_reasoning(content: Any, additional_kwargs: dict[str, Any] | None =
     Supports both OpenAI-style reasoning blocks and ChatOllama's
     ``additional_kwargs['reasoning_content']``.
     """
-    if isinstance(additional_kwargs, dict):
+    if additional_kwargs:
         reasoning_content = additional_kwargs.get("reasoning_content")
         if isinstance(reasoning_content, str):
             return reasoning_content
@@ -43,8 +43,8 @@ def streaming_reasoning(content: Any, additional_kwargs: dict[str, Any] | None =
         entry["text"]
         for block in content
         if isinstance(block, dict) and block.get("type") == "reasoning"
-        for entry in (block.get("summary") or ())
-        if isinstance(entry, dict) and entry.get("type") == "summary_text" and "text" in entry
+        for entry in block.get("summary", ())
+        if isinstance(entry, dict) and entry.get("type") == "summary_text"
     )
 
 
@@ -129,23 +129,16 @@ class ThinkTagParser:
             return []
 
         content = getattr(chunk, "content", None)
-        additional_kwargs = getattr(chunk, "additional_kwargs", None)
-
-        reasoning = streaming_reasoning(content, additional_kwargs)
+        reasoning = streaming_reasoning(content, getattr(chunk, "additional_kwargs", None))
         if reasoning:
-            if hide_reasoning:
-                return []
-            return [{"type": "reasoning_delta", "content": reasoning}]
+            return [] if hide_reasoning else [{"type": "reasoning_delta", "content": reasoning}]
 
         text = streaming_text(content)
         if not text:
             return []
 
-        events: list[dict[str, Any]] = []
-        for kind, delta in self.feed(text):
-            if kind == "reasoning":
-                if not hide_reasoning:
-                    events.append({"type": "reasoning_delta", "content": delta})
-            else:
-                events.append({"type": "text_delta", "content": delta})
-        return events
+        return [
+            {"type": f"{kind}_delta", "content": delta}
+            for kind, delta in self.feed(text)
+            if not (kind == "reasoning" and hide_reasoning)
+        ]

--- a/ollama_agent/tasks/commands.py
+++ b/ollama_agent/tasks/commands.py
@@ -39,9 +39,9 @@ class TasksContext:
 
     console: Console = field(default_factory=Console)
     task_manager: TaskManager = field(default_factory=TaskManager)
-    settings: Settings | None = None
+    settings: Settings = field(default_factory=load_settings)
 
-    def _find_or_exit(self, task_id: str) -> tuple[str, Task]:
+    def _resolve_task(self, task_id: str) -> tuple[str, Task]:
         try:
             matches = self.task_manager.find_matches(task_id)
         except ValueError as exc:
@@ -82,13 +82,12 @@ def list_tasks(ctx: TasksContext) -> None:
 
 
 async def run_task(ctx: TasksContext, task_id: str, *, yolo: bool = False) -> None:
-    tid, t = ctx._find_or_exit(task_id)
+    tid, t = ctx._resolve_task(task_id)
     ctx.console.print(
         _("Executing: {title} ({tid})\nPrompt: {prompt}\nModel: {model} | Effort: {effort}", title=escape(t.title), tid=escape(tid), prompt=escape(t.prompt), model=escape(t.model), effort=escape(t.reasoning_effort))
     )
-    settings = ctx.settings if ctx.settings is not None else load_settings()
-    apply_task_settings(settings, t)
-    runtime = AgentRuntime(settings=settings, yolo_mode=yolo)
+    apply_task_settings(ctx.settings, t)
+    runtime = AgentRuntime(settings=ctx.settings, yolo_mode=yolo)
     async with runtime:
         await runtime.reload()
         if not await run_non_interactive(runtime, t.prompt):
@@ -96,7 +95,7 @@ async def run_task(ctx: TasksContext, task_id: str, *, yolo: bool = False) -> No
 
 
 def delete_task(ctx: TasksContext, task_id: str) -> None:
-    tid, t = ctx._find_or_exit(task_id)
+    tid, t = ctx._resolve_task(task_id)
     ctx.task_manager.delete(tid)
     ctx.console.print(f"[green]✓ {_('Task deleted: {title} ({tid})', title=escape(t.title), tid=escape(tid))}[/green]")
 
@@ -108,15 +107,14 @@ def create_task(
     title: str,
     prompt: str,
     model: str,
-    reasoning_effort: str | None = None,
+    reasoning_effort: str = DEFAULT_REASONING_EFFORT,
     force: bool = False,
 ) -> None:
     title = ctx._require(title, _("Title"))
     prompt_text = ctx._require(prompt, _("Prompt"))
     model_name = ctx._require(model, _("Model"))
-    effort = DEFAULT_REASONING_EFFORT if reasoning_effort is None else reasoning_effort
     try:
-        task = Task(title, prompt_text, model_name, reasoning_effort=effort)
+        task = Task(title, prompt_text, model_name, reasoning_effort=reasoning_effort)
         saved_id = ctx.task_manager.save(task_id, task, overwrite=force)
     except FileExistsError as exc:
         raise TaskError(

--- a/ollama_agent/tasks/manager.py
+++ b/ollama_agent/tasks/manager.py
@@ -66,7 +66,6 @@ class TaskManager(BaseFileStoreManager[Task]):
         path = self._path(task_id)
         if path.exists() and not overwrite:
             raise FileExistsError(_("Task already exists: {task_id}", task_id=task_id))
-        path.parent.mkdir(parents=True, exist_ok=True)
         text = yaml.safe_dump(asdict(task), allow_unicode=True)
         with tempfile.NamedTemporaryFile(
             mode="w",

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -159,16 +159,11 @@ class TestAgentRuntimeComponents(unittest.IsolatedAsyncioTestCase):
 
     def test_list_subagents_empty(self) -> None:
         console = Console(file=io.StringIO(), record=True, width=120)
-        list_subagents(console, None)
+        settings = Settings()
+        list_subagents(console, settings)
         output = console.export_text()
         self.assertIn("No subagents configured.", output)
         self.assertIn("Configure subagents in", output)
-
-        console_empty = Console(file=io.StringIO(), record=True, width=120)
-        settings = Settings()
-        list_subagents(console_empty, settings)
-        output_empty = console_empty.export_text()
-        self.assertIn("No subagents configured.", output_empty)
 
     def test_list_subagents_populated(self) -> None:
         console = Console(file=io.StringIO(), record=True, width=120)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -35,8 +35,9 @@ class TestCommonUtilities(unittest.TestCase):
                 with self.assertRaises(TypeError):
                     extract_text(unknown)
 
-    def test_extract_text_dict_without_text_returns_empty(self) -> None:
-        self.assertEqual(extract_text({"foo": "bar"}), "")
+    def test_extract_text_dict_without_text_raises_type_error(self) -> None:
+        with self.assertRaises(TypeError):
+            extract_text({"foo": "bar"})
 
     def test_validate_identifier_valid_names(self) -> None:
         self.assertEqual(validate_identifier("valid_name-123"), "valid_name-123")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -298,11 +298,51 @@ class TestConfigManagement(unittest.TestCase):
             Settings.from_dict({"modeel": {"name": "llama3"}})
         self.assertIn("modeel", str(ctx.exception))
 
+    def test_find_agents_file_default_start_dir(self) -> None:
+        orig_cwd = Path.cwd()
+        proj_dir = Path(self.temp_dir.name) / "default_dir"
+        proj_dir.mkdir()
+        agents_file = proj_dir / "AGENTS.md"
+        agents_file.write_text("# Default\n", encoding="utf-8")
+        try:
+            os.chdir(proj_dir)
+            found = find_agents_file()
+            self.assertEqual(found, agents_file)
+        finally:
+            os.chdir(orig_cwd)
+
+    def test_dataclass_from_dict_none_returns_default(self) -> None:
+        model = _dataclass_from_dict(ModelSettings, None)
+        self.assertIsInstance(model, ModelSettings)
+        self.assertEqual(model.base_url, "http://localhost:11434")
+
     def test_dataclass_from_dict_rejects_non_dict(self) -> None:
         with self.assertRaises(ValueError):
             _dataclass_from_dict(ModelSettings, "not-a-dict")
         with self.assertRaises(ValueError):
             _dataclass_from_dict(ModelSettings, 123)
+
+    def test_subagents_from_list_parsing(self) -> None:
+        self.assertEqual(_subagents_from_list(None), [])
+        raw = [
+            {
+                "name": "explorer",
+                "description": "Explores",
+            },
+            {
+                "name": "tester",
+                "mcp_servers": [
+                    {"name": "fetch", "command": "uvx", "args": ["mcp-server-fetch"]}
+                ],
+            },
+        ]
+        subagents = _subagents_from_list(raw)
+        self.assertEqual(len(subagents), 2)
+        self.assertEqual(subagents[0].name, "explorer")
+        self.assertEqual(subagents[0].mcp_servers, [])
+        self.assertEqual(subagents[1].name, "tester")
+        self.assertEqual(len(subagents[1].mcp_servers), 1)
+        self.assertEqual(subagents[1].mcp_servers[0].name, "fetch")
 
     def test_subagents_from_list_validation(self) -> None:
         with self.assertRaises(ValueError):

--- a/tests/test_mcp_loader.py
+++ b/tests/test_mcp_loader.py
@@ -17,6 +17,7 @@ from ollama_agent.mcp.commands import (
 from ollama_agent.mcp.loader import (
     MCPConfigError,
     _build_mcp_connection,
+    _load_tools_from_connections,
     _read_main_config,
     _resolve_env,
     load_main_mcp_tools,
@@ -305,6 +306,25 @@ class TestMCPLoader(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(status.transport, "stdio")
             self.assertEqual(status.target, "invalid-cmd")
             self.assertIn("Command not found", status.error)
+
+    async def test_load_tools_from_connections_empty(self) -> None:
+        tools = await _load_tools_from_connections({})
+        self.assertEqual(tools, [])
+
+    async def test_check_mcp_server_timeout(self) -> None:
+        cfg = {"type": "http", "url": "https://mcp.example.com"}
+        mock_client = MagicMock()
+        mock_client.get_tools = AsyncMock(side_effect=TimeoutError())
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("ollama_agent.mcp.commands.MultiServerMCPClient", return_value=mock_client):
+            status = await check_mcp_server("slow-server", cfg, timeout=1.0)
+            self.assertEqual(status.name, "slow-server")
+            self.assertEqual(status.status, "failed")
+            self.assertEqual(status.transport, "http")
+            self.assertEqual(status.target, "https://mcp.example.com")
+            self.assertIn("timed out", status.error)
 
     async def test_check_mcp_server_invalid_config(self) -> None:
         status = await check_mcp_server("invalid-server", {"unknown": "bad"})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,8 +30,7 @@ class TestModelsLogic(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(_parse_num_ctx("num_ctx 4096"), 4096)
         self.assertEqual(_parse_num_ctx("  num_ctx   16384  "), 16384)
 
-    def test_parse_num_ctx_invalid_or_none(self) -> None:
-        self.assertIsNone(_parse_num_ctx(None))
+    def test_parse_num_ctx_invalid(self) -> None:
         self.assertIsNone(_parse_num_ctx(""))
         self.assertIsNone(_parse_num_ctx("temperature 0.7"))
 
@@ -83,7 +82,7 @@ class TestModelsLogic(unittest.IsolatedAsyncioTestCase):
         response_sdk = MagicMock(model_info=None, modelinfo={"gemma.context_length": 8192})
         self.assertEqual(_get_model_info(response_sdk), {"gemma.context_length": 8192})
 
-        self.assertEqual(_get_model_info(MagicMock(model_info="nope", modelinfo=None)), {})
+        self.assertIsNone(_get_model_info(MagicMock(model_info="nope", modelinfo=None)))
 
     @patch("ollama_agent.core.models.get_model_capabilities")
     async def test_model_supports_tools(self, mock_caps: AsyncMock) -> None:
@@ -264,7 +263,7 @@ class TestModelsLogic(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(_parse_modelfile_param(text, "top_k"), "30")
         self.assertEqual(_parse_modelfile_param(text, "repeat_penalty"), "1.15")
         self.assertIsNone(_parse_modelfile_param(text, "min_p"))
-        self.assertIsNone(_parse_modelfile_param(None, "temperature"))
+        self.assertIsNone(_parse_modelfile_param("", "temperature"))
 
     def test_validate_reasoning_effort(self) -> None:
         self.assertEqual(validate_reasoning_effort("  HIGH  "), "high")

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -57,17 +57,17 @@ class TestRAGComponents(unittest.TestCase):
         with self.assertRaises(RAGError):
             self.mgr._read_file(file)
 
-    def test_rag_context_find_or_exit_not_found(self) -> None:
+    def test_rag_context_resolve_database_not_found(self) -> None:
         ctx = RAGContext(rag_manager=self.mgr)
         with self.assertRaises(RAGDatabaseNotFoundError):
-            ctx._find_or_exit("nonexistent_db")
+            ctx.resolve_database("nonexistent_db")
 
-    def test_rag_context_find_or_exit_case_insensitive(self) -> None:
+    def test_rag_context_resolve_database_case_insensitive(self) -> None:
         ctx = RAGContext(rag_manager=self.mgr)
         # Create a database
         self.mgr.create_database("MyDatabase")
         # Find it using lowercase
-        found = ctx._find_or_exit("mydatabase")
+        found = ctx.resolve_database("mydatabase")
         self.assertEqual(found, "MyDatabase")
 
 

--- a/tests/test_rag_manager.py
+++ b/tests/test_rag_manager.py
@@ -189,6 +189,8 @@ class TestRAGManagerAndCommands(unittest.IsolatedAsyncioTestCase):
         f1.write_text("# Doc 1\nSome useful content.", encoding="utf-8")
         f2 = sub_dir / "file2.py"
         f2.write_text("def hello(): return 'world'", encoding="utf-8")
+        f_empty = sub_dir / "empty.txt"
+        f_empty.write_text("   \n", encoding="utf-8")
 
         mock_client = MagicMock()
         self.manager._client = mock_client
@@ -219,7 +221,7 @@ class TestRAGManagerAndCommands(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(RAGNotLoadedError):
             await self.manager.add_file(str(f1))
 
-    def test_rag_context_find_or_exit(self) -> None:
+    def test_rag_context_resolve_database(self) -> None:
         mock_mgr = MagicMock()
         mock_mgr.list_databases.return_value = [
             {"name": "docs", "active": False, "chunks": 10},
@@ -229,13 +231,13 @@ class TestRAGManagerAndCommands(unittest.IsolatedAsyncioTestCase):
         ctx = RAGContext(rag_manager=mock_mgr, console=Console(file=io.StringIO(), record=True))
 
         # Exact match should take priority even if a prefix match exists
-        self.assertEqual(ctx._find_or_exit("docs"), "docs")
-        self.assertEqual(ctx._find_or_exit("docs_v2"), "docs_v2")
-        self.assertEqual(ctx._find_or_exit("code"), "code")
+        self.assertEqual(ctx.resolve_database("docs"), "docs")
+        self.assertEqual(ctx.resolve_database("docs_v2"), "docs_v2")
+        self.assertEqual(ctx.resolve_database("code"), "code")
 
         # Nonexistent DB
         with self.assertRaises(RAGDatabaseNotFoundError):
-            ctx._find_or_exit("nonexistent")
+            ctx.resolve_database("nonexistent")
 
         # Ambiguous prefix
         mock_mgr.list_databases.return_value = [
@@ -243,7 +245,7 @@ class TestRAGManagerAndCommands(unittest.IsolatedAsyncioTestCase):
             {"name": "alpha_2", "active": False, "chunks": 2},
         ]
         with self.assertRaises(AmbiguousRAGDatabaseError):
-            ctx._find_or_exit("alpha")
+            ctx.resolve_database("alpha")
 
     def test_rag_command_handlers(self) -> None:
         console = Console(file=io.StringIO(), record=True)
@@ -282,11 +284,10 @@ class TestRAGManagerAndCommands(unittest.IsolatedAsyncioTestCase):
         content = self.manager._read_file(f_custom, allowed_extensions=frozenset({".custom"}))
         self.assertEqual(content, "custom content")
 
-    def test_delete_sources_points_empty_set_noop(self) -> None:
+    def test_delete_source_points(self) -> None:
         mock_client = MagicMock()
-        # Should early return and not call client.delete
-        self.manager._delete_sources_points(mock_client, set())
-        mock_client.delete.assert_not_called()
+        self.manager._delete_source_points(mock_client, "/path/to/file.py")
+        mock_client.delete.assert_called_once()
 
     def test_create_database_failure_cleanup(self) -> None:
         with patch("ollama_agent.rag.manager.QdrantClient") as mock_qdrant_cls:
@@ -347,17 +348,17 @@ class TestRAGManagerAndCommands(unittest.IsolatedAsyncioTestCase):
         ]
         ctx = RAGContext(rag_manager=mock_mgr, console=Console(file=io.StringIO(), record=True))
         # "alpha" matches "Alpha" exactly (case-insensitive) instead of matching "alphabet" as prefix
-        self.assertEqual(ctx._find_or_exit("alpha"), "Alpha")
+        self.assertEqual(ctx.resolve_database("alpha"), "Alpha")
 
     def test_database_resolution_empty_name_raises(self) -> None:
         mock_mgr = MagicMock()
         mock_mgr.list_databases.return_value = [{"name": "docs", "active": False, "chunks": 5}]
         ctx = RAGContext(rag_manager=mock_mgr, console=Console(file=io.StringIO(), record=True))
         with self.assertRaises(RAGDatabaseNotFoundError) as exc:
-            ctx._find_or_exit("")
+            ctx.resolve_database("")
         self.assertIn("cannot be empty", str(exc.exception))
         with self.assertRaises(RAGDatabaseNotFoundError) as exc:
-            ctx._find_or_exit("   ")
+            ctx.resolve_database("   ")
         self.assertIn("cannot be empty", str(exc.exception))
 
     async def test_add_rag_directory_styling(self) -> None:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -87,11 +87,14 @@ class TestSkillsManager(unittest.TestCase):
             _read_skill(skill_dir)
 
     def test_find_matches_prefix(self) -> None:
+        self.mgr.create("py", name="Python Base", description="Base tool", instructions="Run py")
         self.mgr.create("py-lint", name="Python Linter", description="Lints code", instructions="Run ruff")
         self.mgr.create("py-test", name="Python Tester", description="Runs tests", instructions="Run pytest")
 
-        matches = self.mgr.find_matches("py-")
-        self.assertEqual(len(matches), 2)
+        matches = self.mgr.find_matches("py")
+        self.assertEqual(len(matches), 3)
+        match_ids = [m[0] for m in matches]
+        self.assertEqual(sorted(match_ids), ["py", "py-lint", "py-test"])
 
     def test_delete_skill(self) -> None:
         self.mgr.create("temp-skill", name="T", description="D", instructions="I")

--- a/tests/test_tasks_commands.py
+++ b/tests/test_tasks_commands.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 from rich.console import Console
 
-from ollama_agent.settings import load_settings
+from ollama_agent.settings import Settings, load_settings
 from ollama_agent.tasks.commands import (
     AmbiguousTaskError,
     TasksContext,
@@ -146,13 +146,27 @@ class TestTasksCommands(unittest.IsolatedAsyncioTestCase):
                 model="gemma4:26b",
             )
 
-    def test_find_or_exit_errors(self) -> None:
+    def test_create_task_default_reasoning_effort(self) -> None:
+        create_task(
+            self.ctx,
+            "default-effort-task",
+            title="Default Effort Task",
+            prompt="summarize",
+            model="gemma4:26b",
+        )
+        task = self.mgr.get("default-effort-task")
+        self.assertEqual(task.reasoning_effort, "medium")
+
+    def test_tasks_context_default_settings(self) -> None:
+        self.assertIsInstance(self.ctx.settings, Settings)
+
+    def test_resolve_task_errors(self) -> None:
         with self.assertRaises(TaskNotFoundError):
-            self.ctx._find_or_exit("missing_task")
+            self.ctx._resolve_task("missing_task")
 
         create_task(self.ctx, "deploy-prod", title="Prod Deploy", prompt="deploy", model="gemma4:26b")
         create_task(self.ctx, "deploy-staging", title="Staging Deploy", prompt="deploy", model="gemma4:26b")
 
         with self.assertRaises(AmbiguousTaskError):
-            self.ctx._find_or_exit("deploy")
+            self.ctx._resolve_task("deploy")
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -710,7 +710,7 @@ class TestOllamaAgentApp(unittest.IsolatedAsyncioTestCase):
         repl_mock._get_commands.return_value = {}
 
         task = MagicMock(title="My Task", model="task-model", reasoning_effort="high", prompt="Do things")
-        repl_mock._task_ctx._find_or_exit.return_value = ("my-task", task)
+        repl_mock._task_ctx._resolve_task.return_value = ("my-task", task)
 
         app = OllamaAgentApp(repl_mock)
         async with app.run_test() as pilot:


### PR DESCRIPTION
- core: remove catch-and-swallow in prompt processor, strictly type modelfile parser, fail loud in extract_text
- i18n & root: linearize set_locale startup flow and simplify text resolution
- tasks: strictly type TasksContext.settings, rename _resolve_task, remove redundant mkdir
- skills: fix prefix matching shadowed by catch-and-swallow, remove unrequested safe defaults
- settings: strictly type start_dir in find_agents_file, use generic dataclass loader
- mcp: extract _load_tools_from_connections helper, direct dict key checks, clean TimeoutError handling
- rag: unify point deletion, remove exception-based control flow in add_directory, clean QdrantClient lifecycle
- streaming: simplify defensive checks in parsers and renderers, eliminate dead code
- agent: remove redundant graph/model null checks, clean state.values access, strictly type subagents list
- interfaces: use connect_history context manager in session delete, clean TUI header and interrupt handling